### PR TITLE
chore(firebase): initialize Firebase Emulator Suite

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "joinme-aa9e8"
+  }
+}

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,14 @@
+{
+  "emulators": {
+    "auth": {
+      "port": 9099
+    },
+    "firestore": {
+      "port": 8080
+    },
+    "ui": {
+      "enabled": true
+    },
+    "singleProjectMode": true
+  }
+}


### PR DESCRIPTION
This commit sets up the Firebase Emulator Suite to allow local development and testing without depending on production services.