### PR TITLE
feat(history): add HistoryViewModel for expired events

### DIFF
--- a/app/src/main/java/com/android/joinme/ui/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/android/joinme/ui/history/HistoryViewModel.kt
@@ -1,0 +1,75 @@
+package com.android.joinme.ui.history
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.android.joinme.model.event.Event
+import com.android.joinme.model.event.EventsRepository
+import com.android.joinme.model.event.EventsRepositoryProvider
+import com.android.joinme.model.event.isExpired
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Represents the UI state for the History screen.
+ *
+ * @property expiredEvents A list of expired `Event` items to be displayed in the History screen.
+ *   Defaults to an empty list if no items are available.
+ * @property errorMsg An error message to be shown when fetching events fails. `null` if no error is
+ *   present.
+ */
+data class HistoryUIState(
+    val expiredEvents: List<Event> = emptyList(),
+    val errorMsg: String? = null,
+)
+
+/**
+ * ViewModel for the History screen.
+ *
+ * Responsible for managing the UI state, by fetching and providing expired Event items via the
+ * [EventsRepository].
+ *
+ * @property eventRepository The repository used to fetch and manage Event items.
+ */
+class HistoryViewModel(
+    private val eventRepository: EventsRepository =
+        EventsRepositoryProvider.getRepository(isOnline = true)
+) : ViewModel() {
+
+  private val _uiState = MutableStateFlow(HistoryUIState())
+  val uiState: StateFlow<HistoryUIState> = _uiState.asStateFlow()
+
+  /** Clears the error message in the UI state. */
+  fun clearErrorMsg() {
+    _uiState.value = _uiState.value.copy(errorMsg = null)
+  }
+
+  /** Sets an error message in the UI state. */
+  private fun setErrorMsg(errorMsg: String) {
+    _uiState.value = _uiState.value.copy(errorMsg = errorMsg)
+  }
+
+  /** Refreshes the UI state by fetching all expired Event items from the repository. */
+  fun refreshUIState() {
+    getExpiredEvents()
+  }
+
+  /** Fetches all expired events from the repository and updates the UI state. */
+  private fun getExpiredEvents() {
+    viewModelScope.launch {
+      try {
+        val allEvents = eventRepository.getAllEvents()
+
+        val expired =
+            allEvents.filter { it.isExpired() }.sortedByDescending { it.date.toDate().time }
+
+        _uiState.value = HistoryUIState(expiredEvents = expired)
+      } catch (e: Exception) {
+        Log.e("HistoryViewModel", "Error fetching expired events", e)
+        setErrorMsg("Failed to load history: ${e.message}")
+      }
+    }
+  }
+}

--- a/app/src/test/java/com/android/joinme/ui/history/HistoryViewModelTest.kt
+++ b/app/src/test/java/com/android/joinme/ui/history/HistoryViewModelTest.kt
@@ -1,0 +1,305 @@
+package com.android.joinme.ui.history
+
+import com.android.joinme.model.event.Event
+import com.android.joinme.model.event.EventType
+import com.android.joinme.model.event.EventVisibility
+import com.android.joinme.model.event.EventsRepository
+import com.google.firebase.Timestamp
+import java.util.Calendar
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for [HistoryViewModel].
+ *
+ * Verifies UI state updates and error handling when interacting with the repository.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class HistoryViewModelTest {
+
+  private val testDispatcher = StandardTestDispatcher()
+
+  private lateinit var fakeRepository: FakeEventsRepository
+  private lateinit var viewModel: HistoryViewModel
+
+  @Before
+  fun setup() {
+    Dispatchers.setMain(testDispatcher)
+    fakeRepository = FakeEventsRepository()
+    viewModel = HistoryViewModel(eventRepository = fakeRepository)
+  }
+
+  @After
+  fun tearDown() {
+    Dispatchers.resetMain()
+  }
+
+  @Test
+  fun `refreshUIState loads expired events successfully`() = runTest {
+    fakeRepository.shouldThrow = false
+
+    viewModel.refreshUIState()
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    val state = viewModel.uiState.value
+    assertNull(state.errorMsg)
+    assertEquals(1, state.expiredEvents.size)
+    assertEquals("Expired Event", state.expiredEvents[0].title)
+  }
+
+  @Test
+  fun `getExpiredEvents updates errorMsg on repository failure`() = runTest {
+    fakeRepository.shouldThrow = true
+
+    viewModel.refreshUIState()
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    val state = viewModel.uiState.value
+    assertNotNull(state.errorMsg)
+    assertTrue(state.expiredEvents.isEmpty())
+    assertTrue(state.errorMsg!!.contains("Failed to load history"))
+  }
+
+  @Test
+  fun `clearErrorMsg clears existing error`() = runTest {
+    fakeRepository.shouldThrow = true
+    viewModel.refreshUIState()
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    viewModel.clearErrorMsg()
+    val state = viewModel.uiState.value
+
+    assertNull(state.errorMsg)
+  }
+
+  @Test
+  fun `refreshUIState fetches only expired events`() = runTest {
+    fakeRepository.shouldThrow = false
+
+    viewModel.refreshUIState()
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    val state = viewModel.uiState.value
+    // Should only contain the expired event, not the ongoing or upcoming ones
+    assertEquals(1, state.expiredEvents.size)
+    assertEquals("Expired Event", state.expiredEvents[0].title)
+  }
+
+  @Test
+  fun `expired events are sorted in descending order by date`() = runTest {
+    fakeRepository.shouldThrow = false
+    fakeRepository.addMultipleExpiredEvents()
+
+    viewModel.refreshUIState()
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    val state = viewModel.uiState.value
+
+    // Should have 3 expired events (1 from default + 2 added)
+    assertTrue(state.expiredEvents.size >= 2)
+
+    // Check that events are sorted by date in descending order (most recent first)
+    for (i in 0 until state.expiredEvents.size - 1) {
+      assertTrue(
+          state.expiredEvents[i].date.toDate().time >=
+              state.expiredEvents[i + 1].date.toDate().time)
+    }
+  }
+
+  @Test
+  fun `uiState starts with empty expiredEvents list`() = runTest {
+    val state = viewModel.uiState.value
+    assertTrue(state.expiredEvents.isEmpty())
+    assertNull(state.errorMsg)
+  }
+
+  @Test
+  fun `refreshUIState handles empty repository`() = runTest {
+    fakeRepository.clearAllEvents()
+
+    viewModel.refreshUIState()
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    val state = viewModel.uiState.value
+    assertNull(state.errorMsg)
+    assertTrue(state.expiredEvents.isEmpty())
+  }
+
+  @Test
+  fun `refreshUIState excludes ongoing events`() = runTest {
+    fakeRepository.shouldThrow = false
+
+    viewModel.refreshUIState()
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    val state = viewModel.uiState.value
+
+    // Should not contain any ongoing events
+    state.expiredEvents.forEach { event ->
+      val now = System.currentTimeMillis()
+      val startTime = event.date.toDate().time
+      val endTime = startTime + (event.duration * 60 * 1000)
+      // Verify event is not ongoing
+      assertTrue(endTime <= now)
+    }
+  }
+
+  @Test
+  fun `refreshUIState excludes upcoming events`() = runTest {
+    fakeRepository.shouldThrow = false
+
+    viewModel.refreshUIState()
+    testDispatcher.scheduler.advanceUntilIdle()
+
+    val state = viewModel.uiState.value
+
+    // Should not contain any upcoming events
+    state.expiredEvents.forEach { event ->
+      val now = System.currentTimeMillis()
+      // Verify event is not upcoming
+      assertTrue(event.date.toDate().time <= now)
+    }
+  }
+
+  /** Fake implementation of [EventsRepository] for isolated ViewModel testing. */
+  private class FakeEventsRepository : EventsRepository {
+    var shouldThrow = false
+
+    private val fakeEvents = mutableListOf<Event>()
+
+    init {
+      // Add default test events
+      val calendar = Calendar.getInstance()
+
+      // Add an expired event (ended 2 hours ago)
+      calendar.add(Calendar.HOUR, -3)
+      fakeEvents.add(
+          Event(
+              eventId = "1",
+              type = EventType.SPORTS,
+              title = "Expired Event",
+              description = "Desc 1",
+              location = null,
+              date = Timestamp(calendar.time),
+              duration = 60,
+              participants = listOf("user1"),
+              maxParticipants = 10,
+              visibility = EventVisibility.PUBLIC,
+              ownerId = "owner1"))
+
+      // Add an ongoing event (started 30 minutes ago, lasts 2 hours)
+      calendar.time = Calendar.getInstance().time
+      calendar.add(Calendar.MINUTE, -30)
+      fakeEvents.add(
+          Event(
+              eventId = "2",
+              type = EventType.SOCIAL,
+              title = "Ongoing Event",
+              description = "Desc 2",
+              location = null,
+              date = Timestamp(calendar.time),
+              duration = 120,
+              participants = emptyList(),
+              maxParticipants = 5,
+              visibility = EventVisibility.PRIVATE,
+              ownerId = "owner2"))
+
+      // Add an upcoming event (starts in 2 hours)
+      calendar.time = Calendar.getInstance().time
+      calendar.add(Calendar.HOUR, 2)
+      fakeEvents.add(
+          Event(
+              eventId = "3",
+              type = EventType.ACTIVITY,
+              title = "Upcoming Event",
+              description = "Desc 3",
+              location = null,
+              date = Timestamp(calendar.time),
+              duration = 60,
+              participants = emptyList(),
+              maxParticipants = 8,
+              visibility = EventVisibility.PUBLIC,
+              ownerId = "owner3"))
+    }
+
+    fun addMultipleExpiredEvents() {
+      val calendar = Calendar.getInstance()
+
+      // Add an expired event from yesterday
+      calendar.add(Calendar.DAY_OF_MONTH, -1)
+      fakeEvents.add(
+          Event(
+              eventId = "4",
+              type = EventType.SPORTS,
+              title = "Yesterday Event",
+              description = "Desc 4",
+              location = null,
+              date = Timestamp(calendar.time),
+              duration = 60,
+              participants = emptyList(),
+              maxParticipants = 10,
+              visibility = EventVisibility.PUBLIC,
+              ownerId = "owner4"))
+
+      // Add an expired event from last week
+      calendar.time = Calendar.getInstance().time
+      calendar.add(Calendar.DAY_OF_MONTH, -7)
+      fakeEvents.add(
+          Event(
+              eventId = "5",
+              type = EventType.SOCIAL,
+              title = "Last Week Event",
+              description = "Desc 5",
+              location = null,
+              date = Timestamp(calendar.time),
+              duration = 90,
+              participants = emptyList(),
+              maxParticipants = 15,
+              visibility = EventVisibility.PUBLIC,
+              ownerId = "owner5"))
+    }
+
+    fun clearAllEvents() {
+      fakeEvents.clear()
+    }
+
+    override suspend fun getAllEvents(): List<Event> {
+      if (shouldThrow) throw RuntimeException("Repository error")
+      return fakeEvents
+    }
+
+    override suspend fun getEvent(eventId: String): Event {
+      if (shouldThrow) throw RuntimeException("Repository error")
+      return fakeEvents.first { it.eventId == eventId }
+    }
+
+    override suspend fun addEvent(event: Event) {
+      if (shouldThrow) throw RuntimeException("Repository error")
+      fakeEvents.add(event)
+    }
+
+    override suspend fun editEvent(eventId: String, newValue: Event) {
+      if (shouldThrow) throw RuntimeException("Repository error")
+    }
+
+    override suspend fun deleteEvent(eventId: String) {
+      if (shouldThrow) throw RuntimeException("Repository error")
+    }
+
+    override fun getNewEventId(): String {
+      if (shouldThrow) throw RuntimeException("Repository error")
+      return "new_event_id"
+    }
+  }
+}


### PR DESCRIPTION
## Description
This PR adds the HistoryViewModel to manage and display expired events in the application.

## Changes
- **HistoryViewModel**: New ViewModel that fetches expired events from the repository
  - Filters events using the `isExpired()` extension function
  - Sorts events by date in descending order (most recent first)
  - Follows the same MVVM pattern as OverviewViewModel

- **HistoryUIState**: Data class containing:
  - `expiredEvents`: List of expired Event items
  - `errorMsg`: Error message for failed fetch operations

- **State Management**:
  - Uses StateFlow for reactive UI updates
  - Error handling with toast messages
  - Refresh functionality via `refreshUIState()`

- **Tests**: Comprehensive unit tests covering:
  - Empty state handling
  - Event filtering and sorting
  - Error scenarios
  - State updates

## Next Steps
The UI for the History screen will be added in a follow-up PR to keep this PR focused and under the line limit.