### PR TITLE
refactor: update OverviewScreen title

### DIFF
--- a/app/src/androidTest/java/com/android/joinme/ui/overview/OverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/android/joinme/ui/overview/OverviewScreenTest.kt
@@ -455,7 +455,7 @@ class OverviewScreenTest {
   }
 
   @Test
-  fun overviewScreen_topBarDisplaysWelcomeMessage() {
+  fun overviewScreen_topBarDisplaysOverviewTitle() {
     val repo = EventsRepositoryLocal()
     val viewModel = OverviewViewModel(repo)
 
@@ -463,7 +463,7 @@ class OverviewScreenTest {
 
     composeTestRule.waitForIdle()
 
-    composeTestRule.onNodeWithText("Welcome, Mathieu").assertExists()
+    composeTestRule.onNodeWithText("Overview").assertExists()
   }
 
   @Test

--- a/app/src/main/java/com/android/joinme/ui/overview/OverviewScreen.kt
+++ b/app/src/main/java/com/android/joinme/ui/overview/OverviewScreen.kt
@@ -88,7 +88,7 @@ fun OverviewScreen(
               modifier = Modifier.testTag(NavigationTestTags.TOP_BAR_TITLE),
               title = {
                 Text(
-                    text = "Welcome, Mathieu",
+                    text = "Overview",
                     style = MaterialTheme.typography.titleLarge,
                     modifier = Modifier.fillMaxWidth(),
                     textAlign = TextAlign.Center)


### PR DESCRIPTION
## Description
This PR removes the hardcoded username from the OverviewScreen welcome message and replaces it with a generic title.

## Changes
- Remove hardcoded "Welcome, Mathieu" from TopAppBar title
- Replace with generic welcome message "Overview"

## Rationale
The previous implementation used a hardcoded username "Welcome, Mathieu" which was a temporary placeholder. We cannot implement dynamic username display at this time because:

1. **No local profile repository**: We don't have a `ProfileRepositoryLocal` implementation for testing
2. **Test failures**: Navigation tests fail when ProfileViewModel tries to fetch data from Firestore

## Future Work
Once `ProfileRepositoryLocal` is implemented and proper test mocking is in place, we can add dynamic username display with:
- ProfileViewModel integration
- Proper repository mocking in tests
- User-specific welcome messages