### PR TITLE
feat(serie): add SeriesRepository implementations

### DIFF
--- a/app/src/main/java/com/android/joinme/model/serie/SeriesRepository.kt
+++ b/app/src/main/java/com/android/joinme/model/serie/SeriesRepository.kt
@@ -1,0 +1,57 @@
+package com.android.joinme.model.serie
+
+/**
+ * Repository interface for managing Serie (event series) data operations.
+ *
+ * Provides CRUD operations for series, which are collections of recurring events that share common
+ * properties like title, description, and visibility.
+ */
+interface SeriesRepository {
+
+  /**
+   * Generates and returns a new unique identifier for a Serie item.
+   *
+   * @return A new unique Serie ID string
+   */
+  fun getNewSerieId(): String
+
+  /**
+   * Retrieves all Serie items from the repository.
+   *
+   * @return A list of all Serie items
+   */
+  suspend fun getAllSeries(): List<Serie>
+
+  /**
+   * Retrieves a specific Serie item by its unique identifier.
+   *
+   * @param serieId The unique identifier of the Serie item to retrieve
+   * @return The Serie item with the specified identifier
+   * @throws Exception if the Serie item is not found
+   */
+  suspend fun getSerie(serieId: String): Serie
+
+  /**
+   * Adds a new Serie item to the repository.
+   *
+   * @param serie The Serie item to add
+   */
+  suspend fun addSerie(serie: Serie)
+
+  /**
+   * Edits an existing Serie item in the repository.
+   *
+   * @param serieId The unique identifier of the Serie item to edit
+   * @param newValue The new value for the Serie item
+   * @throws Exception if the Serie item is not found
+   */
+  suspend fun editSerie(serieId: String, newValue: Serie)
+
+  /**
+   * Deletes a Serie item from the repository.
+   *
+   * @param serieId The unique identifier of the Serie item to delete
+   * @throws Exception if the Serie item is not found
+   */
+  suspend fun deleteSerie(serieId: String)
+}

--- a/app/src/main/java/com/android/joinme/model/serie/SeriesRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/joinme/model/serie/SeriesRepositoryFirestore.kt
@@ -1,0 +1,134 @@
+package com.android.joinme.model.serie
+
+import android.util.Log
+import com.android.joinme.model.utils.Visibility
+import com.google.firebase.Firebase
+import com.google.firebase.auth.auth
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+
+/** Firestore collection path for series documents */
+const val SERIES_COLLECTION_PATH = "series"
+
+/**
+ * Firestore-backed implementation of [SeriesRepository].
+ *
+ * Manages CRUD operations for [Serie] objects stored in Firebase Firestore. All operations are
+ * performed asynchronously using Kotlin coroutines.
+ *
+ * @property db The FirebaseFirestore instance used for database operations
+ */
+class SeriesRepositoryFirestore(private val db: FirebaseFirestore) : SeriesRepository {
+  /** Field name for the owner ID in Firestore documents */
+  private val ownerAttributeName = "ownerId"
+
+  /**
+   * Generates and returns a new unique identifier for a Serie item.
+   *
+   * Uses Firestore's auto-generated document IDs to ensure uniqueness.
+   *
+   * @return A new unique Serie ID string
+   */
+  override fun getNewSerieId(): String {
+    return db.collection(SERIES_COLLECTION_PATH).document().id
+  }
+
+  /**
+   * Retrieves all Serie items owned by the currently authenticated user.
+   *
+   * @return A list of all Serie items owned by the current user
+   * @throws Exception if the user is not logged in
+   */
+  override suspend fun getAllSeries(): List<Serie> {
+    val ownerId =
+        Firebase.auth.currentUser?.uid
+            ?: throw Exception("SeriesRepositoryFirestore: User not logged in.")
+
+    val snapshot =
+        db.collection(SERIES_COLLECTION_PATH)
+            .whereEqualTo(ownerAttributeName, ownerId)
+            .get()
+            .await()
+
+    return snapshot.mapNotNull { documentToSerie(it) }
+  }
+
+  /**
+   * Retrieves a specific Serie item by its unique identifier from Firestore.
+   *
+   * @param serieId The unique identifier of the Serie item to retrieve
+   * @return The Serie item with the specified identifier
+   * @throws Exception if the Serie item is not found in Firestore
+   */
+  override suspend fun getSerie(serieId: String): Serie {
+    val document = db.collection(SERIES_COLLECTION_PATH).document(serieId).get().await()
+    return documentToSerie(document)
+        ?: throw Exception("SeriesRepositoryFirestore: Serie not found ($serieId)")
+  }
+
+  /**
+   * Adds a new Serie item to Firestore.
+   *
+   * @param serie The Serie item to add
+   */
+  override suspend fun addSerie(serie: Serie) {
+    db.collection(SERIES_COLLECTION_PATH).document(serie.serieId).set(serie).await()
+  }
+
+  /**
+   * Edits an existing Serie item in Firestore.
+   *
+   * Replaces the entire Serie document with the new value.
+   *
+   * @param serieId The unique identifier of the Serie item to edit
+   * @param newValue The new value for the Serie item
+   */
+  override suspend fun editSerie(serieId: String, newValue: Serie) {
+    db.collection(SERIES_COLLECTION_PATH).document(serieId).set(newValue).await()
+  }
+
+  /**
+   * Deletes a Serie item from Firestore.
+   *
+   * @param serieId The unique identifier of the Serie item to delete
+   */
+  override suspend fun deleteSerie(serieId: String) {
+    db.collection(SERIES_COLLECTION_PATH).document(serieId).delete().await()
+  }
+
+  /**
+   * Converts a Firestore document to a [Serie] object.
+   *
+   * Extracts all Serie fields from the Firestore document and constructs a Serie instance. Returns
+   * null if any required fields are missing or if conversion fails.
+   *
+   * @param document The Firestore document to convert
+   * @return The [Serie] object, or null if conversion fails
+   */
+  private fun documentToSerie(document: DocumentSnapshot): Serie? {
+    return try {
+      val serieId = document.id
+      val title = document.getString("title") ?: return null
+      val description = document.getString("description") ?: ""
+      val date = document.getTimestamp("date") ?: return null
+      val maxParticipants = (document.getLong("maxParticipants") ?: 0L).toInt()
+      val visibilityString = document.getString("visibility") ?: Visibility.PUBLIC.name
+      val eventIds = document.get("eventIds") as? List<String> ?: emptyList()
+      val ownerId = document.getString("ownerId") ?: return null
+
+      Serie(
+          serieId = serieId,
+          title = title,
+          description = description,
+          date = date,
+          maxParticipants = maxParticipants,
+          visibility = Visibility.valueOf(visibilityString),
+          eventIds = eventIds,
+          ownerId = ownerId)
+    } catch (e: Exception) {
+      Log.e("SeriesRepositoryFirestore", "Error converting document to Serie", e)
+      null
+    }
+  }
+}

--- a/app/src/main/java/com/android/joinme/model/serie/SeriesRepositoryLocal.kt
+++ b/app/src/main/java/com/android/joinme/model/serie/SeriesRepositoryLocal.kt
@@ -1,0 +1,89 @@
+package com.android.joinme.model.serie
+
+/**
+ * Local in-memory implementation of SeriesRepository.
+ *
+ * This implementation stores Serie objects in a mutable list and is primarily used for testing and
+ * offline functionality. Data is not persisted and will be lost when the application is closed.
+ */
+class SeriesRepositoryLocal : SeriesRepository {
+  /** In-memory storage for Serie objects */
+  private val series: MutableList<Serie> = mutableListOf()
+
+  /** Counter for generating unique Serie IDs */
+  private var counter = 0
+
+  /**
+   * Generates and returns a new unique identifier for a Serie item.
+   *
+   * IDs are generated sequentially starting from 0.
+   *
+   * @return A new unique Serie ID string
+   */
+  override fun getNewSerieId(): String {
+    return (counter++).toString()
+  }
+
+  /**
+   * Retrieves all Serie items from the local storage.
+   *
+   * @return A list of all Serie items currently stored
+   */
+  override suspend fun getAllSeries(): List<Serie> {
+    return series
+  }
+
+  /**
+   * Retrieves a specific Serie item by its unique identifier.
+   *
+   * @param serieId The unique identifier of the Serie item to retrieve
+   * @return The Serie item with the specified identifier
+   * @throws Exception if the Serie item is not found in local storage
+   */
+  override suspend fun getSerie(serieId: String): Serie {
+    return series.find { it.serieId == serieId }
+        ?: throw Exception("SeriesRepositoryLocal: Serie not found")
+  }
+
+  /**
+   * Adds a new Serie item to the local storage.
+   *
+   * @param serie The Serie item to add
+   */
+  override suspend fun addSerie(serie: Serie) {
+    series.add(serie)
+  }
+
+  /**
+   * Edits an existing Serie item in the local storage.
+   *
+   * Replaces the existing Serie with the new value at the same index.
+   *
+   * @param serieId The unique identifier of the Serie item to edit
+   * @param newValue The new value for the Serie item
+   * @throws Exception if the Serie item is not found in local storage
+   */
+  override suspend fun editSerie(serieId: String, newValue: Serie) {
+    val index = series.indexOfFirst { it.serieId == serieId }
+    if (index != -1) {
+      series[index] = newValue
+    } else {
+      throw Exception("SeriesRepositoryLocal: Serie not found")
+    }
+  }
+
+  /**
+   * Deletes a Serie item from the local storage.
+   *
+   * @param serieId The unique identifier of the Serie item to delete
+   * @throws Exception if the Serie item is not found in local storage
+   */
+  override suspend fun deleteSerie(serieId: String) {
+    val index = series.indexOfFirst { it.serieId == serieId }
+    if (index != -1) {
+      series.removeAt(index)
+    } else {
+      throw Exception("SeriesRepositoryLocal: Serie not found")
+    }
+  }
+}

--- a/app/src/main/java/com/android/joinme/model/serie/SeriesRepositoryProvider.kt
+++ b/app/src/main/java/com/android/joinme/model/serie/SeriesRepositoryProvider.kt
@@ -1,0 +1,26 @@
+package com.android.joinme.model.serie
+
+import com.google.firebase.Firebase
+import com.google.firebase.firestore.firestore
+
+/**
+ * Provides a singleton instance of the SeriesRepository for dependency injection.
+ *
+ * This provider follows the repository pattern and enables easy testing by allowing the repository
+ * instance to be swapped with a mock or fake implementation. By default, it provides a Firestore-
+ * backed implementation.
+ */
+object SeriesRepositoryProvider {
+  /**
+   * Lazily initialized private instance of the repository using Firebase Firestore as the backend.
+   */
+  private val _repository: SeriesRepository by lazy {
+    SeriesRepositoryFirestore(Firebase.firestore)
+  }
+
+  /**
+   * The current repository instance used throughout the application. Can be reassigned for testing
+   * purposes to inject fake or mock implementations.
+   */
+  var repository: SeriesRepository = _repository
+}

--- a/app/src/test/java/com/android/joinme/model/serie/SeriesRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/joinme/model/serie/SeriesRepositoryFirestoreTest.kt
@@ -1,0 +1,324 @@
+package com.android.joinme.model.serie
+
+import com.android.joinme.model.utils.Visibility
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.Timestamp
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.QuerySnapshot
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import java.util.Date
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+
+class SeriesRepositoryFirestoreTest {
+
+  private lateinit var mockDb: FirebaseFirestore
+  private lateinit var mockCollection: CollectionReference
+  private lateinit var mockDocument: DocumentReference
+  private lateinit var mockAuth: FirebaseAuth
+  private lateinit var mockUser: FirebaseUser
+  private lateinit var repository: SeriesRepositoryFirestore
+
+  private val testSerieId = "testSerie123"
+  private val testUserId = "testUser456"
+  private val testSerie =
+      Serie(
+          serieId = testSerieId,
+          title = "Weekly Football",
+          description = "Weekly football series at the park",
+          date = Timestamp(Date()),
+          maxParticipants = 10,
+          visibility = Visibility.PUBLIC,
+          eventIds = listOf("event1", "event2", "event3"),
+          ownerId = testUserId)
+
+  @Before
+  fun setup() {
+    // Mock Firestore
+    mockDb = mockk(relaxed = true)
+    mockCollection = mockk(relaxed = true)
+    mockDocument = mockk(relaxed = true)
+
+    // Mock Firebase Auth
+    mockAuth = mockk(relaxed = true)
+    mockUser = mockk(relaxed = true)
+
+    every { mockDb.collection(SERIES_COLLECTION_PATH) } returns mockCollection
+    every { mockCollection.document(any()) } returns mockDocument
+    every { mockCollection.document() } returns mockDocument
+    every { mockDocument.id } returns testSerieId
+
+    repository = SeriesRepositoryFirestore(mockDb)
+  }
+
+  @Test
+  fun getNewSerieId_returnsValidId() {
+    // When
+    val serieId = repository.getNewSerieId()
+
+    // Then
+    assertNotNull(serieId)
+    assertEquals(testSerieId, serieId)
+    verify { mockDb.collection(SERIES_COLLECTION_PATH) }
+    verify { mockCollection.document() }
+  }
+
+  @Test
+  fun addSerie_callsFirestoreSet() = runTest {
+    // Given
+    every { mockDocument.set(any()) } returns Tasks.forResult(null)
+
+    // When
+    repository.addSerie(testSerie)
+
+    // Then
+    verify { mockCollection.document(testSerieId) }
+    verify { mockDocument.set(testSerie) }
+  }
+
+  @Test
+  fun getSerie_returnsSerieSuccessfully() = runTest {
+    // Given
+    val mockSnapshot = mockk<DocumentSnapshot>(relaxed = true)
+    every { mockDocument.get() } returns Tasks.forResult(mockSnapshot)
+    every { mockSnapshot.id } returns testSerieId
+    every { mockSnapshot.getString("title") } returns "Weekly Football"
+    every { mockSnapshot.getString("description") } returns "Weekly football series at the park"
+    every { mockSnapshot.getTimestamp("date") } returns testSerie.date
+    every { mockSnapshot.getLong("maxParticipants") } returns 10L
+    every { mockSnapshot.getString("visibility") } returns Visibility.PUBLIC.name
+    every { mockSnapshot.get("eventIds") } returns listOf("event1", "event2", "event3")
+    every { mockSnapshot.getString("ownerId") } returns testUserId
+
+    // When
+    val result = repository.getSerie(testSerieId)
+
+    // Then
+    assertNotNull(result)
+    assertEquals(testSerieId, result.serieId)
+    assertEquals("Weekly Football", result.title)
+    assertEquals(testUserId, result.ownerId)
+    assertEquals(3, result.eventIds.size)
+  }
+
+  @Test
+  fun editSerie_callsFirestoreUpdate() = runTest {
+    // Given
+    val updatedSerie = testSerie.copy(title = "Updated Title")
+    every { mockDocument.set(any()) } returns Tasks.forResult(null)
+
+    // When
+    repository.editSerie(testSerieId, updatedSerie)
+
+    // Then
+    verify { mockCollection.document(testSerieId) }
+    verify { mockDocument.set(updatedSerie) }
+  }
+
+  @Test
+  fun deleteSerie_callsFirestoreDelete() = runTest {
+    // Given
+    every { mockDocument.delete() } returns Tasks.forResult(null)
+
+    // When
+    repository.deleteSerie(testSerieId)
+
+    // Then
+    verify { mockCollection.document(testSerieId) }
+    verify { mockDocument.delete() }
+  }
+
+  @Test
+  fun getAllSeries_returnsSeriesForCurrentUser() = runTest {
+    // Given
+    mockkStatic(FirebaseAuth::class)
+    every { FirebaseAuth.getInstance() } returns mockAuth
+    every { mockAuth.currentUser } returns mockUser
+    every { mockUser.uid } returns testUserId
+
+    val mockQuery = mockk<com.google.firebase.firestore.Query>(relaxed = true)
+    val mockQuerySnapshot = mockk<QuerySnapshot>(relaxed = true)
+    val mockSnapshot1 = mockk<com.google.firebase.firestore.QueryDocumentSnapshot>(relaxed = true)
+    val mockSnapshot2 = mockk<com.google.firebase.firestore.QueryDocumentSnapshot>(relaxed = true)
+
+    every { mockCollection.whereEqualTo("ownerId", testUserId) } returns mockQuery
+    every { mockQuery.get() } returns Tasks.forResult(mockQuerySnapshot)
+    every { mockQuerySnapshot.iterator() } returns
+        mutableListOf(mockSnapshot1, mockSnapshot2).iterator()
+
+    // Setup first serie
+    every { mockSnapshot1.id } returns "serie1"
+    every { mockSnapshot1.getString("title") } returns "Serie 1"
+    every { mockSnapshot1.getString("description") } returns "Description 1"
+    every { mockSnapshot1.getTimestamp("date") } returns Timestamp(Date())
+    every { mockSnapshot1.getLong("maxParticipants") } returns 10L
+    every { mockSnapshot1.getString("visibility") } returns Visibility.PUBLIC.name
+    every { mockSnapshot1.get("eventIds") } returns listOf("event1")
+    every { mockSnapshot1.getString("ownerId") } returns testUserId
+
+    // Setup second serie
+    every { mockSnapshot2.id } returns "serie2"
+    every { mockSnapshot2.getString("title") } returns "Serie 2"
+    every { mockSnapshot2.getString("description") } returns "Description 2"
+    every { mockSnapshot2.getTimestamp("date") } returns Timestamp(Date())
+    every { mockSnapshot2.getLong("maxParticipants") } returns 8L
+    every { mockSnapshot2.getString("visibility") } returns Visibility.PRIVATE.name
+    every { mockSnapshot2.get("eventIds") } returns listOf("event2", "event3")
+    every { mockSnapshot2.getString("ownerId") } returns testUserId
+
+    // When
+    val result = repository.getAllSeries()
+
+    // Then
+    assertEquals(2, result.size)
+    assertEquals("Serie 1", result[0].title)
+    assertEquals("Serie 2", result[1].title)
+  }
+
+  @Test(expected = Exception::class)
+  fun getSerie_throwsExceptionWhenNotFound() = runTest {
+    // Given
+    val mockSnapshot = mockk<DocumentSnapshot>(relaxed = true)
+    every { mockDocument.get() } returns Tasks.forResult(mockSnapshot)
+    every { mockSnapshot.getString("title") } returns null // Missing required field
+
+    // When
+    repository.getSerie(testSerieId)
+
+    // Then - exception is thrown
+  }
+
+  @Test(expected = Exception::class)
+  fun getAllSeries_throwsExceptionWhenUserNotLoggedIn() = runTest {
+    // Given
+    mockkStatic(FirebaseAuth::class)
+    every { FirebaseAuth.getInstance() } returns mockAuth
+    every { mockAuth.currentUser } returns null // User not logged in
+
+    // When
+    repository.getAllSeries()
+
+    // Then - exception is thrown
+  }
+
+  @Test(expected = Exception::class)
+  fun documentToSerie_handlesExceptionGracefully() = runTest {
+    // Given
+    val mockSnapshot = mockk<DocumentSnapshot>(relaxed = true)
+    every { mockDocument.get() } returns Tasks.forResult(mockSnapshot)
+    every { mockSnapshot.id } returns testSerieId
+    every { mockSnapshot.getString("title") } returns "Test Serie"
+    every { mockSnapshot.getString("description") } returns "Description"
+    every { mockSnapshot.getTimestamp("date") } returns Timestamp(Date())
+    every { mockSnapshot.getLong("maxParticipants") } returns 10L
+    every { mockSnapshot.getString("visibility") } returns
+        "INVALID_VISIBILITY" // Invalid enum value
+    every { mockSnapshot.get("eventIds") } returns listOf("event1")
+    every { mockSnapshot.getString("ownerId") } returns testUserId
+
+    // When - documentToSerie catches the exception and returns null
+    // getSerie then throws because documentToSerie returned null
+    repository.getSerie(testSerieId)
+
+    // Then - exception is thrown because documentToSerie returned null
+  }
+
+  @Test
+  fun getSerie_withEmptyEventIds() = runTest {
+    // Given
+    val mockSnapshot = mockk<DocumentSnapshot>(relaxed = true)
+    every { mockDocument.get() } returns Tasks.forResult(mockSnapshot)
+    every { mockSnapshot.id } returns testSerieId
+    every { mockSnapshot.getString("title") } returns "Empty Serie"
+    every { mockSnapshot.getString("description") } returns "Serie with no events"
+    every { mockSnapshot.getTimestamp("date") } returns testSerie.date
+    every { mockSnapshot.getLong("maxParticipants") } returns 5L
+    every { mockSnapshot.getString("visibility") } returns Visibility.PUBLIC.name
+    every { mockSnapshot.get("eventIds") } returns emptyList<String>()
+    every { mockSnapshot.getString("ownerId") } returns testUserId
+
+    // When
+    val result = repository.getSerie(testSerieId)
+
+    // Then
+    assertNotNull(result)
+    assertEquals(0, result.eventIds.size)
+  }
+
+  @Test
+  fun getSerie_withPrivateVisibility() = runTest {
+    // Given
+    val mockSnapshot = mockk<DocumentSnapshot>(relaxed = true)
+    every { mockDocument.get() } returns Tasks.forResult(mockSnapshot)
+    every { mockSnapshot.id } returns testSerieId
+    every { mockSnapshot.getString("title") } returns "Private Serie"
+    every { mockSnapshot.getString("description") } returns "Private serie description"
+    every { mockSnapshot.getTimestamp("date") } returns testSerie.date
+    every { mockSnapshot.getLong("maxParticipants") } returns 5L
+    every { mockSnapshot.getString("visibility") } returns Visibility.PRIVATE.name
+    every { mockSnapshot.get("eventIds") } returns listOf("event1")
+    every { mockSnapshot.getString("ownerId") } returns testUserId
+
+    // When
+    val result = repository.getSerie(testSerieId)
+
+    // Then
+    assertNotNull(result)
+    assertEquals(Visibility.PRIVATE, result.visibility)
+  }
+
+  @Test
+  fun getSerie_withDefaultVisibilityWhenNull() = runTest {
+    // Given
+    val mockSnapshot = mockk<DocumentSnapshot>(relaxed = true)
+    every { mockDocument.get() } returns Tasks.forResult(mockSnapshot)
+    every { mockSnapshot.id } returns testSerieId
+    every { mockSnapshot.getString("title") } returns "Serie with default visibility"
+    every { mockSnapshot.getString("description") } returns "Description"
+    every { mockSnapshot.getTimestamp("date") } returns testSerie.date
+    every { mockSnapshot.getLong("maxParticipants") } returns 10L
+    every { mockSnapshot.getString("visibility") } returns null // Null visibility
+    every { mockSnapshot.get("eventIds") } returns listOf("event1")
+    every { mockSnapshot.getString("ownerId") } returns testUserId
+
+    // When
+    val result = repository.getSerie(testSerieId)
+
+    // Then
+    assertNotNull(result)
+    assertEquals(Visibility.PUBLIC, result.visibility) // Should default to PUBLIC
+  }
+
+  @Test
+  fun getSerie_withEmptyDescriptionDefaultsToEmpty() = runTest {
+    // Given
+    val mockSnapshot = mockk<DocumentSnapshot>(relaxed = true)
+    every { mockDocument.get() } returns Tasks.forResult(mockSnapshot)
+    every { mockSnapshot.id } returns testSerieId
+    every { mockSnapshot.getString("title") } returns "Serie Title"
+    every { mockSnapshot.getString("description") } returns null // Null description
+    every { mockSnapshot.getTimestamp("date") } returns testSerie.date
+    every { mockSnapshot.getLong("maxParticipants") } returns 10L
+    every { mockSnapshot.getString("visibility") } returns Visibility.PUBLIC.name
+    every { mockSnapshot.get("eventIds") } returns listOf("event1")
+    every { mockSnapshot.getString("ownerId") } returns testUserId
+
+    // When
+    val result = repository.getSerie(testSerieId)
+
+    // Then
+    assertNotNull(result)
+    assertEquals("", result.description) // Should default to empty string
+  }
+}

--- a/app/src/test/java/com/android/joinme/model/serie/SeriesRepositoryLocalTest.kt
+++ b/app/src/test/java/com/android/joinme/model/serie/SeriesRepositoryLocalTest.kt
@@ -1,0 +1,216 @@
+package com.android.joinme.model.serie
+
+import com.android.joinme.model.utils.Visibility
+import com.google.firebase.Timestamp
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class SeriesRepositoryLocalTest {
+
+  private lateinit var repo: SeriesRepositoryLocal
+  private lateinit var sampleSerie: Serie
+
+  @Before
+  fun setup() {
+    repo = SeriesRepositoryLocal()
+    sampleSerie =
+        Serie(
+            serieId = "1",
+            title = "Weekly Football",
+            description = "Weekly football series at the park",
+            date = Timestamp.now(),
+            maxParticipants = 10,
+            visibility = Visibility.PUBLIC,
+            eventIds = listOf("event1", "event2", "event3"),
+            ownerId = "user1")
+  }
+
+  // ---------------- BASIC CRUD ----------------
+
+  @Test
+  fun addAndGetSerie_success() {
+    runBlocking {
+      repo.addSerie(sampleSerie)
+      val serie = repo.getSerie("1")
+      Assert.assertEquals(sampleSerie.title, serie.title)
+    }
+  }
+
+  @Test(expected = Exception::class)
+  fun getSerie_notFound_throwsException() {
+    runBlocking { repo.getSerie("unknown") }
+  }
+
+  @Test
+  fun editSerie_updatesSuccessfully() {
+    runBlocking {
+      repo.addSerie(sampleSerie)
+      val updated = sampleSerie.copy(title = "Updated Title")
+      repo.editSerie("1", updated)
+      val serie = repo.getSerie("1")
+      Assert.assertEquals("Updated Title", serie.title)
+    }
+  }
+
+  @Test
+  fun deleteSerie_removesSuccessfully() {
+    runBlocking {
+      repo.addSerie(sampleSerie)
+      repo.deleteSerie("1")
+      val all = repo.getAllSeries()
+      Assert.assertTrue(all.isEmpty())
+    }
+  }
+
+  // ---------------- ADDITIONAL TESTS ----------------
+
+  @Test
+  fun addMultipleSeries_storesAll() {
+    runBlocking {
+      val s1 = sampleSerie
+      val s2 = sampleSerie.copy(serieId = "2", title = "Basketball Series")
+      val s3 = sampleSerie.copy(serieId = "3", title = "Tennis Series")
+      repo.addSerie(s1)
+      repo.addSerie(s2)
+      repo.addSerie(s3)
+
+      val all = repo.getAllSeries()
+      Assert.assertEquals(3, all.size)
+      Assert.assertTrue(all.any { it.title == "Tennis Series" })
+    }
+  }
+
+  @Test
+  fun getNewSerieId_incrementsSequentially() {
+    val id1 = repo.getNewSerieId()
+    val id2 = repo.getNewSerieId()
+    val id3 = repo.getNewSerieId()
+    Assert.assertEquals((id1.toInt() + 1).toString(), id2)
+    Assert.assertEquals((id2.toInt() + 1).toString(), id3)
+  }
+
+  @Test(expected = Exception::class)
+  fun editSerie_notFound_throwsException() {
+    runBlocking {
+      val fake = sampleSerie.copy(serieId = "999", title = "DoesNotExist")
+      repo.editSerie(fake.serieId, fake)
+    }
+  }
+
+  @Test(expected = Exception::class)
+  fun deleteSerie_notFound_throwsException() {
+    runBlocking {
+      repo.addSerie(sampleSerie)
+      repo.deleteSerie("nonexistent")
+    }
+  }
+
+  @Test
+  fun addDuplicateId_keepsOriginalOnGet() {
+    runBlocking {
+      repo.addSerie(sampleSerie)
+      val duplicate = sampleSerie.copy(title = "Duplicate Serie")
+      repo.addSerie(duplicate)
+
+      // getSerie returns the first matching item (original)
+      val fetched = repo.getSerie("1")
+      Assert.assertEquals("Weekly Football", fetched.title)
+
+      // and both entries exist with the same ID
+      val allWithSameId = repo.getAllSeries().filter { it.serieId == "1" }
+      Assert.assertEquals(2, allWithSameId.size)
+    }
+  }
+
+  @Test
+  fun getAllSeries_returnsEmptyListInitially() {
+    runBlocking {
+      val all = repo.getAllSeries()
+      Assert.assertTrue(all.isEmpty())
+    }
+  }
+
+  @Test
+  fun editSerie_preservesOtherSeries() {
+    runBlocking {
+      val s1 = sampleSerie
+      val s2 = sampleSerie.copy(serieId = "2", title = "Basketball Series")
+      repo.addSerie(s1)
+      repo.addSerie(s2)
+
+      val updated = s1.copy(title = "Updated Football")
+      repo.editSerie("1", updated)
+
+      val serie1 = repo.getSerie("1")
+      val serie2 = repo.getSerie("2")
+      Assert.assertEquals("Updated Football", serie1.title)
+      Assert.assertEquals("Basketball Series", serie2.title)
+    }
+  }
+
+  @Test
+  fun deleteSerie_preservesOtherSeries() {
+    runBlocking {
+      val s1 = sampleSerie
+      val s2 = sampleSerie.copy(serieId = "2", title = "Basketball Series")
+      val s3 = sampleSerie.copy(serieId = "3", title = "Tennis Series")
+      repo.addSerie(s1)
+      repo.addSerie(s2)
+      repo.addSerie(s3)
+
+      repo.deleteSerie("2")
+
+      val all = repo.getAllSeries()
+      Assert.assertEquals(2, all.size)
+      Assert.assertTrue(all.any { it.serieId == "1" })
+      Assert.assertTrue(all.any { it.serieId == "3" })
+      Assert.assertFalse(all.any { it.serieId == "2" })
+    }
+  }
+
+  @Test
+  fun editSerie_withDifferentVisibility() {
+    runBlocking {
+      repo.addSerie(sampleSerie)
+      val updated = sampleSerie.copy(visibility = Visibility.PRIVATE)
+      repo.editSerie("1", updated)
+      val serie = repo.getSerie("1")
+      Assert.assertEquals(Visibility.PRIVATE, serie.visibility)
+    }
+  }
+
+  @Test
+  fun editSerie_withDifferentEventIds() {
+    runBlocking {
+      repo.addSerie(sampleSerie)
+      val updated = sampleSerie.copy(eventIds = listOf("event4", "event5"))
+      repo.editSerie("1", updated)
+      val serie = repo.getSerie("1")
+      Assert.assertEquals(2, serie.eventIds.size)
+      Assert.assertTrue(serie.eventIds.contains("event4"))
+      Assert.assertTrue(serie.eventIds.contains("event5"))
+    }
+  }
+
+  @Test
+  fun addSerie_withEmptyEventIds() {
+    runBlocking {
+      val emptyEventsSerie = sampleSerie.copy(serieId = "2", eventIds = emptyList())
+      repo.addSerie(emptyEventsSerie)
+      val serie = repo.getSerie("2")
+      Assert.assertTrue(serie.eventIds.isEmpty())
+    }
+  }
+
+  @Test
+  fun addSerie_withPrivateVisibility() {
+    runBlocking {
+      val privateSerie = sampleSerie.copy(serieId = "2", visibility = Visibility.PRIVATE)
+      repo.addSerie(privateSerie)
+      val serie = repo.getSerie("2")
+      Assert.assertEquals(Visibility.PRIVATE, serie.visibility)
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR implements the repository layer for the `Serie` model, providing both local and Firestore-based data access. This allows switching between offline testing and production environments.

## Changes

### Repository Interface
- Created `SeriesRepository` interface :
  - `getNewSerieId()`: Generate unique serie identifiers
  - `getAllSeries()`: Retrieve all series
  - `getSerie(serieId)`: Get a specific serie by ID
  - `addSerie(serie)`: Create a new serie
  - `editSerie(serieId, newValue)`: Update an existing serie
  - `deleteSerie(serieId)`: Remove a serie

### Implementations

**SeriesRepositoryLocal**
- In-memory implementation using MutableStateFlow
- Ideal for unit testing and offline development
- Provides immediate data access without network calls

**SeriesRepositoryFirestore**
- Cloud-based implementation using Firebase Firestore
- Production-ready with error handling
- Integrates with existing EventsRepository for event lookups
- Supports real-time data synchronization

### Repository Provider
- `SeriesRepositoryProvider` to switch between local/Firestore implementations


Closes #[148]