### PR TITLE
fix(events): ensure event owner is automatically included as participant

### DIFF
--- a/app/src/androidTest/java/com/android/joinme/ui/overview/EditEventScreenTest.kt
+++ b/app/src/androidTest/java/com/android/joinme/ui/overview/EditEventScreenTest.kt
@@ -28,7 +28,7 @@ class EditEventScreenTest {
         location = Location(46.5197, 6.6323, "EPFL"),
         date = Timestamp(calendar.time),
         duration = 90,
-        participants = listOf("user1", "user2"),
+        participants = listOf("user1"),
         maxParticipants = 10,
         visibility = EventVisibility.PUBLIC,
         ownerId = "owner123")

--- a/app/src/androidTest/java/com/android/joinme/ui/overview/OverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/android/joinme/ui/overview/OverviewScreenTest.kt
@@ -69,7 +69,7 @@ class OverviewScreenTest {
         location = null,
         date = Timestamp(Date()),
         duration = 60,
-        participants = emptyList(),
+        participants = listOf("owner"),
         maxParticipants = 5,
         visibility = EventVisibility.PUBLIC,
         ownerId = "owner")

--- a/app/src/androidTest/java/com/android/joinme/ui/overview/ShowEventScreenTest.kt
+++ b/app/src/androidTest/java/com/android/joinme/ui/overview/ShowEventScreenTest.kt
@@ -17,7 +17,7 @@ class ShowEventScreenTest {
   private fun createTestEvent(
       eventId: String = "test-event-1",
       ownerId: String = "owner123",
-      participants: List<String> = listOf("user1", "user2"),
+      participants: List<String> = listOf("user1", "user2", "owner123"),
       maxParticipants: Int = 10,
       daysFromNow: Int = 7 // Future event by default
   ): Event {
@@ -108,7 +108,7 @@ class ShowEventScreenTest {
     composeTestRule.onNodeWithTag(ShowEventScreenTestTags.EVENT_LOCATION).assertTextContains("EPFL")
     composeTestRule
         .onNodeWithTag(ShowEventScreenTestTags.EVENT_MEMBERS)
-        .assertTextContains("MEMBERS : 2/10")
+        .assertTextContains("MEMBERS : 3/10")
     composeTestRule
         .onNodeWithTag(ShowEventScreenTestTags.EVENT_DURATION)
         .assertTextContains("90min")
@@ -296,7 +296,7 @@ class ShowEventScreenTest {
   @Test
   fun nonOwnerSeesJoinQuitButton() {
     val repo = EventsRepositoryLocal()
-    val event = createTestEvent(ownerId = "owner123", participants = listOf("user1"))
+    val event = createTestEvent(ownerId = "owner123", participants = listOf("user1", "owner123"))
     runBlocking { repo.addEvent(event) }
     val viewModel = ShowEventViewModel(repo)
 
@@ -321,7 +321,8 @@ class ShowEventScreenTest {
   @Test
   fun nonParticipantSeesJoinButton() {
     val repo = EventsRepositoryLocal()
-    val event = createTestEvent(ownerId = "owner123", participants = listOf("user1", "user2"))
+    val event =
+        createTestEvent(ownerId = "owner123", participants = listOf("user1", "user2", "owner123"))
     runBlocking { repo.addEvent(event) }
     val viewModel = ShowEventViewModel(repo)
 
@@ -346,7 +347,8 @@ class ShowEventScreenTest {
   @Test
   fun participantSeesQuitButton() {
     val repo = EventsRepositoryLocal()
-    val event = createTestEvent(ownerId = "owner123", participants = listOf("user1", "user2"))
+    val event =
+        createTestEvent(ownerId = "owner123", participants = listOf("user1", "user2", "owner123"))
     runBlocking { repo.addEvent(event) }
     val viewModel = ShowEventViewModel(repo)
 
@@ -371,7 +373,7 @@ class ShowEventScreenTest {
   @Test
   fun clickingJoinButton_addsUserToParticipants() {
     val repo = EventsRepositoryLocal()
-    val event = createTestEvent(ownerId = "owner123", participants = listOf("user1"))
+    val event = createTestEvent(ownerId = "owner123", participants = listOf("user1", "owner123"))
     runBlocking { repo.addEvent(event) }
     val viewModel = ShowEventViewModel(repo)
 
@@ -391,7 +393,7 @@ class ShowEventScreenTest {
     // Verify initial state
     composeTestRule
         .onNodeWithTag(ShowEventScreenTestTags.EVENT_MEMBERS)
-        .assertTextContains("MEMBERS : 1/10")
+        .assertTextContains("MEMBERS : 2/10")
     composeTestRule
         .onNodeWithTag(ShowEventScreenTestTags.JOIN_QUIT_BUTTON)
         .assertTextContains("JOIN EVENT")
@@ -406,7 +408,7 @@ class ShowEventScreenTest {
     // Verify user was added
     composeTestRule
         .onNodeWithTag(ShowEventScreenTestTags.EVENT_MEMBERS)
-        .assertTextContains("MEMBERS : 2/10")
+        .assertTextContains("MEMBERS : 3/10")
     composeTestRule
         .onNodeWithTag(ShowEventScreenTestTags.JOIN_QUIT_BUTTON)
         .assertTextContains("QUIT EVENT")
@@ -415,7 +417,8 @@ class ShowEventScreenTest {
   @Test
   fun clickingQuitButton_removesUserFromParticipants() {
     val repo = EventsRepositoryLocal()
-    val event = createTestEvent(ownerId = "owner123", participants = listOf("user1", "user2"))
+    val event =
+        createTestEvent(ownerId = "owner123", participants = listOf("user1", "user2", "owner123"))
     runBlocking { repo.addEvent(event) }
     val viewModel = ShowEventViewModel(repo)
 
@@ -435,7 +438,7 @@ class ShowEventScreenTest {
     // Verify initial state
     composeTestRule
         .onNodeWithTag(ShowEventScreenTestTags.EVENT_MEMBERS)
-        .assertTextContains("MEMBERS : 2/10")
+        .assertTextContains("MEMBERS : 3/10")
     composeTestRule
         .onNodeWithTag(ShowEventScreenTestTags.JOIN_QUIT_BUTTON)
         .assertTextContains("QUIT EVENT")
@@ -450,7 +453,7 @@ class ShowEventScreenTest {
     // Verify user was removed
     composeTestRule
         .onNodeWithTag(ShowEventScreenTestTags.EVENT_MEMBERS)
-        .assertTextContains("MEMBERS : 1/10")
+        .assertTextContains("MEMBERS : 2/10")
     composeTestRule
         .onNodeWithTag(ShowEventScreenTestTags.JOIN_QUIT_BUTTON)
         .assertTextContains("JOIN EVENT")
@@ -593,7 +596,7 @@ class ShowEventScreenTest {
     // Create event with max participants already reached
     val event =
         createTestEvent(
-            ownerId = "owner123", participants = listOf("user1", "user2"), maxParticipants = 2)
+            ownerId = "owner123", participants = listOf("user1", "owner123"), maxParticipants = 2)
     runBlocking { repo.addEvent(event) }
     val viewModel = ShowEventViewModel(repo)
 

--- a/app/src/main/java/com/android/joinme/model/event/EventsRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/joinme/model/event/EventsRepositoryFirestore.kt
@@ -44,7 +44,11 @@ class EventsRepositoryFirestore(private val db: FirebaseFirestore) : EventsRepos
   }
 
   override suspend fun addEvent(event: Event) {
-    db.collection(EVENTS_COLLECTION_PATH).document(event.eventId).set(event).await()
+    val ownerId = event.ownerId
+
+    val updatedEvent = event.copy(participants = (event.participants + ownerId).distinct())
+
+    db.collection(EVENTS_COLLECTION_PATH).document(updatedEvent.eventId).set(updatedEvent).await()
   }
 
   override suspend fun editEvent(eventId: String, newValue: Event) {

--- a/app/src/main/java/com/android/joinme/model/event/EventsRepositoryLocal.kt
+++ b/app/src/main/java/com/android/joinme/model/event/EventsRepositoryLocal.kt
@@ -19,7 +19,13 @@ class EventsRepositoryLocal : EventsRepository {
   }
 
   override suspend fun addEvent(event: Event) {
-    events.add(event)
+    // ensure creator is participant
+    val fixedEvent =
+        if (!event.participants.contains(event.ownerId))
+            event.copy(participants = event.participants + event.ownerId)
+        else event
+
+    events.add(fixedEvent)
   }
 
   override suspend fun editEvent(eventId: String, newValue: Event) {

--- a/app/src/test/java/com/android/joinme/model/event/EventsRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/joinme/model/event/EventsRepositoryFirestoreTest.kt
@@ -41,7 +41,7 @@ class EventsRepositoryFirestoreTest {
           location = Location(46.52, 6.63, "EPFL Café"),
           date = Timestamp(Date()),
           duration = 60,
-          participants = listOf("user1", "user2"),
+          participants = listOf("user1", "user2", testUserId),
           maxParticipants = 5,
           visibility = EventVisibility.PUBLIC,
           ownerId = testUserId)

--- a/app/src/test/java/com/android/joinme/ui/overview/EditEventViewModelTest.kt
+++ b/app/src/test/java/com/android/joinme/ui/overview/EditEventViewModelTest.kt
@@ -36,7 +36,7 @@ class EditEventViewModelTest {
         location = Location(46.5197, 6.6323, "EPFL"),
         date = Timestamp(calendar.time),
         duration = 90,
-        participants = listOf("user1", "user2"),
+        participants = listOf("user1", "owner123"),
         maxParticipants = 10,
         visibility = EventVisibility.PUBLIC,
         ownerId = "owner123")
@@ -74,7 +74,7 @@ class EditEventViewModelTest {
     assertEquals("14:30", state.time)
     assertEquals("PUBLIC", state.visibility)
     assertEquals("owner123", state.ownerId)
-    assertEquals(listOf("user1", "user2"), state.participants)
+    assertEquals(listOf("user1", "owner123"), state.participants)
     assertNull(state.errorMsg)
   }
 
@@ -683,8 +683,7 @@ class EditEventViewModelTest {
   @Test
   fun loadEvent_thenSetInvalidMaxParticipants_errorMessageShowsCurrentCount() = runTest {
     // Create event with 5 participants
-    val event =
-        createTestEvent().copy(participants = listOf("user1", "user2", "user3", "user4", "user5"))
+    val event = createTestEvent().copy(participants = listOf("user1", "user2", "user3", "user4"))
     repository.addEvent(event)
 
     viewModel.loadEvent(event.eventId)

--- a/app/src/test/java/com/android/joinme/ui/overview/ShowEventViewModelTest.kt
+++ b/app/src/test/java/com/android/joinme/ui/overview/ShowEventViewModelTest.kt
@@ -77,13 +77,13 @@ class ShowEventViewModelTest {
     assertEquals("Friendly 3v3 basketball match", state.description)
     assertEquals("EPFL", state.location)
     assertEquals("10", state.maxParticipants)
-    assertEquals("2", state.participantsCount)
+    assertEquals("3", state.participantsCount)
     assertEquals("90", state.duration)
     assertTrue(state.date.contains("SPORTS:"))
     assertEquals("PUBLIC", state.visibility)
     assertEquals("owner123", state.ownerId)
     assertTrue(state.ownerName.contains("OWNER123"))
-    assertEquals(listOf("user1", "user2"), state.participants)
+    assertEquals(listOf("user1", "user2", "owner123"), state.participants)
     assertFalse(state.isPastEvent)
     assertNull(state.errorMsg)
   }
@@ -186,7 +186,7 @@ class ShowEventViewModelTest {
 
     val state = viewModel.uiState.first()
     assertTrue(state.participants.contains("user2"))
-    assertEquals("2", state.participantsCount)
+    assertEquals("3", state.participantsCount)
     assertNull(state.errorMsg)
   }
 
@@ -204,7 +204,7 @@ class ShowEventViewModelTest {
 
     val state = viewModel.uiState.first()
     assertFalse(state.participants.contains("user2"))
-    assertEquals("1", state.participantsCount)
+    assertEquals("2", state.participantsCount)
   }
 
   @Test


### PR DESCRIPTION
### Fix — Creator not added to participants upon event creation

Previously, when a user created an event, they were set as `ownerId` but not
automatically added to the `participants` list. This caused inconsistencies in
logic relying on `participants`, especially for features like displaying "You are
participating" or counting attendees.

### What was done

- Enforced invariant inside repositories (Local + Firestore)
- Before persisting the event, we check if `ownerId` is in participants;
  if not, we insert it
- Keeps the logic centralized at the repository layer
- Changed all tests related to it and are now correct

### Why this matters

Ensures all created events have a consistent internal structure and prevents
edge cases later in UI and business logic.

No breaking changes. 