### PR TITLE
refactor(ci): update CI timeout for android tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
           fi
 
       - name: Run instrumentation tests
-        timeout-minutes: 25
+        timeout-minutes: 40
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34


### PR DESCRIPTION
## Description

The CI runner has a timeout of 25 minutes for android tests. Since our app is growing fast, and has a lot of tests, this timeout is changed to 40 minutes.

Closes #161 