### PR TITLE
revert(CI): restore working single-job CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,176 +13,26 @@ on:
       - reopened
 
 jobs:
-  # Job A: Build and Lint
-  build-and-lint:
-    name: Build and Lint
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+  joinme-ci:
+    name: CI-JoinMe
+    runs-on: ubuntu-latest
+
+    env:
+      app_name: JoinMeDebug
 
     steps:
+      # First step : Checkout the repository on the runner
       - name: Checkout
         uses: actions/checkout@v3
         with:
           submodules: recursive
-          fetch-depth: 0
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of Sonar analysis (if we use Sonar Later)
 
-      - name: Setup JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: "temurin"
-          java-version: "17"
+      # This step removes the current gradle cache to avoid any caching issues
+      - name: Remove current gradle cache
+        run: rm -rf ~/.gradle
 
-      - name: Retrieve gradle cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-
-      - name: Decode secrets
-        env:
-          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
-          LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
-        run: |
-          if [ -n "$GOOGLE_SERVICES" ]; then
-            echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
-          else
-            echo "::warning::GOOGLE_SERVICES secret is not set. google-services.json will not be created."
-          fi
-          if [ -n "$LOCAL_PROPERTIES" ]; then
-            echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
-          else
-            echo "::warning::LOCAL_PROPERTIES secret is not set. local.properties will not be created."
-          fi
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x ./gradlew
-
-      - name: KTFmt Check
-        run: ./gradlew ktfmtCheck
-
-      - name: Assemble and Lint
-        run: ./gradlew assembleDebug assembleDebugAndroidTest lint --parallel --build-cache
-
-      - name: Upload APKs for instrumentation tests
-        uses: actions/upload-artifact@v4
-        with:
-          name: apks
-          path: |
-            app/build/outputs/apk/debug/*.apk
-            app/build/outputs/apk/androidTest/debug/*.apk
-
-  # Job B: Unit Tests
-  unit-tests:
-    name: Unit Tests
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          fetch-depth: 0
-
-      - name: Setup JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: "temurin"
-          java-version: "17"
-
-      - name: Retrieve gradle cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-
-      - name: Decode secrets
-        env:
-          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
-          LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
-        run: |
-          if [ -n "$GOOGLE_SERVICES" ]; then
-            echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
-          else
-            echo "::warning::GOOGLE_SERVICES secret is not set. google-services.json will not be created."
-          fi
-          if [ -n "$LOCAL_PROPERTIES" ]; then
-            echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
-          else
-            echo "::warning::LOCAL_PROPERTIES secret is not set. local.properties will not be created."
-          fi
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x ./gradlew
-
-      - name: Setup NodeJS
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
-      - name: Install Firebase CLI
-        run: npm install -g firebase-tools
-
-      - name: Firestore Security Rules tests
-        run: |
-          if [ ! -e "firebase.json" ]; then
-            echo "Warning: 'firebase.json' file is missing. Use 'firebase emulators:init'."
-            exit 0
-          fi
-          jq -e '.emulators' firebase.json >/dev/null || {
-            echo "'firebase.json' is missing 'emulators'. Run 'firebase emulators:init'."
-            exit 1
-          }
-          for e in auth firestore; do
-            jq -e ".emulators.$e" firebase.json >/dev/null || {
-              echo "'firebase.json' is missing 'emulators.$e'. Run 'firebase emulators:init'."
-              exit 1
-            }
-          done
-          if [ -e "firebase/firestore/firestore.rules" ]; then
-            jq -e '.firestore.rules' firebase.json >/dev/null || {
-              echo "'firebase.json' is missing 'firestore.rules'."
-              exit 1
-            }
-            (cd firebase/firestore/test 2>/dev/null && npm install && npm test) || exit $?
-          else
-            echo "Warning: Firestore rules file not found in firebase/firestore."
-          fi
-
-      - name: Run unit tests
-        run: ./gradlew test --parallel --build-cache
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: unit-test-results
-          path: |
-            app/build/reports/tests
-            app/build/test-results
-            app/build/jacoco
-            app/build/outputs/unit_test_code_coverage
-
-  # Job C: Instrumentation Tests with Sharding
-  instrumentation-tests:
-    name: Instrumentation Tests (Shard ${{ matrix.shard }})
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: build-and-lint
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [0, 1]  # Split tests into 2 shards - adjust based on your test suite size
-        # For more shards: [0, 1, 2, 3] would give you 4 parallel runs
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          fetch-depth: 0
-
+      # Kernel-based Virtual Machine (KVM) is an open source virtualization technology built into Linux. Enabling it allows the Android emulator to run faster.
       - name: Enable KVM group perms
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -195,6 +45,11 @@ jobs:
           distribution: "temurin"
           java-version: "17"
 
+
+      # Caching is a very useful part of a CI, as a workflow is executed in a clean environement every time,
+      # this means that one would need to re-download and re-process gradle files for every run. Which is very time consuming.
+      #
+      # To avoid that, we cache the the gradle folder to reuse it later.
       - name: Retrieve gradle cache
         uses: actions/cache@v3
         with:
@@ -203,6 +58,7 @@ jobs:
             ~/.gradle/wrapper
           key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
+      # Load google-services.json from the secrets
       - name: Decode secrets
         env:
           GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
@@ -220,134 +76,92 @@ jobs:
           fi
 
       - name: Grant execute permission for gradlew
-        run: chmod +x ./gradlew
+        run: |
+          chmod +x ./gradlew
 
-      - name: Download APKs
-        uses: actions/download-artifact@v4
-        with:
-          name: apks
-          path: app/build/outputs/apk
-
+      # Install NodeJS
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
           node-version: 22
 
+      # Install Firebase CLI
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
 
+      - name: Firestore Security Rules tests
+        run: |
+          if [ ! -e "firebase.json" ]; then # Check if firebase.json exists
+            echo "'firebase.json' file is missing. Use 'firebase emulators:init'."
+            exit 0
+          fi
+          jq -e '.emulators' firebase.json >/dev/null || { # Check if emulators are configured
+            echo "'firebase.json' is missing 'emulators'. Run 'firebase emulators:init'."
+            exit 1
+          }
+          for e in auth firestore; do # Check if auth and firestore emulators are configured
+            jq -e ".emulators.$e" firebase.json >/dev/null || {
+              echo "'firebase.json' is missing 'emulators.$e'. Run 'firebase emulators:init'."
+              exit 1
+            }
+          done
+          if [ -e "firebase/firestore/firestore.rules" ]; then # Check if firestore.rules exists
+            # Check if firestore.rules is referenced in firebase.json
+            jq -e '.firestore.rules' firebase.json >/dev/null || {
+              echo "'firebase.json' is missing 'firestore.rules'."
+              exit 1
+            }
+            (cd firebase/firestore/test 2>/dev/null && npm install && npm test) || exit $?
+          else
+            echo "Firestore rules file not found in firebase/firestore."
+          fi
+
+      - name: KTFmt Check
+        run: |
+          # To run the CI with debug informations, add --info
+          ./gradlew ktfmtCheck
+
+      # This step runs gradle commands to build the application
+      - name: Assemble
+        run: |
+          # To run the CI with debug information, add --info
+          ./gradlew assembleDebug lint --parallel --build-cache
+
+      - name: Run tests
+        run: |
+          # To run the CI with debug information, add --info
+          ./gradlew check --parallel --build-cache
+
+      # Start Firebase emulators for instrumentation tests
       - name: Start Firebase emulators
         run: |
           if [ -e "firebase.json" ] && jq -e '.emulators' firebase.json >/dev/null; then
             echo "Starting Firebase emulators for instrumentation tests..."
             firebase emulators:start --only auth,firestore --project demo-project &
-            # Wait for emulators to be ready
-            sleep 10
             echo "Firebase emulators started"
           else
             echo "Firebase emulators not configured, skipping emulator startup..."
           fi
 
-      - name: Verify runner resources
-        run: |
-          nproc
-          free -h
-          lsmod | grep kvm || echo "KVM module not visible (emulator may be slower)"
-
-      - name: Run instrumentation tests (Shard ${{ matrix.shard }})
-        timeout-minutes: 40
+      - name: Run instrumentation tests
+        timeout-minutes: 25
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34
           target: google_apis
           arch: x86_64
-          avd-name: github-shard-${{ matrix.shard }}
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -skin 1080x2340
+          avd-name: github
+          force-avd-creation: true
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -skin 1080x2400
           disable-animations: true
-          script: ./gradlew connectedCheck -Pandroid.testInstrumentationRunnerArguments.numShards=2 -Pandroid.testInstrumentationRunnerArguments.shardIndex=${{ matrix.shard }} --parallel --build-cache
+          script: ./gradlew connectedCheck --parallel --build-cache
 
-      - name: Upload instrumentation test results
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: instrumentation-test-results-shard-${{ matrix.shard }}
-          path: |
-            app/build/reports/androidTests
-            app/build/outputs/androidTest-results
-            app/build/outputs/code_coverage
-
-  # Job D: Coverage and Sonar Analysis
-  coverage-and-sonar:
-    name: Coverage and Sonar Analysis
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    needs: [build-and-lint, unit-tests, instrumentation-tests]
-    if: always()
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          fetch-depth: 0
-
-      - name: Setup JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: "temurin"
-          java-version: "17"
-
-      - name: Retrieve gradle cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-
-      - name: Decode secrets
-        env:
-          GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES }}
-          LOCAL_PROPERTIES: ${{ secrets.LOCAL_PROPERTIES }}
+      # This step generates the coverage report which will be used later in the semster for monitoring purposes
+      - name: Generate coverage
         run: |
-          if [ -n "$GOOGLE_SERVICES" ]; then
-            echo "$GOOGLE_SERVICES" | base64 --decode > ./app/google-services.json
-          else
-            echo "::warning::GOOGLE_SERVICES secret is not set. google-services.json will not be created."
-          fi
-          if [ -n "$LOCAL_PROPERTIES" ]; then
-            echo "$LOCAL_PROPERTIES" | base64 --decode > ./local.properties
-          else
-            echo "::warning::LOCAL_PROPERTIES secret is not set. local.properties will not be created."
-          fi
+          ./gradlew jacocoTestReport
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x ./gradlew
-
-      - name: Download unit test results
-        uses: actions/download-artifact@v4
-        with:
-          name: unit-test-results
-          path: app/build
-        continue-on-error: true
-
-      - name: Download instrumentation test results (Shard 0)
-        uses: actions/download-artifact@v4
-        with:
-          name: instrumentation-test-results-shard-0
-          path: app/build
-        continue-on-error: true
-
-      - name: Download instrumentation test results (Shard 1)
-        uses: actions/download-artifact@v4
-        with:
-          name: instrumentation-test-results-shard-1
-          path: app/build
-        continue-on-error: true
-
-      - name: Generate coverage report
-        run: ./gradlew jacocoTestReport
-
+      # Fix invalid line numbers in JaCoCo XML report (Compose synthetic code issue)
       - name: Fix JaCoCo XML report
         run: |
           python3 << 'EOF'
@@ -400,17 +214,14 @@ jobs:
           print("JaCoCo XML report validation complete")
           EOF
 
-      - name: Upload coverage report
+      - name: Upload coverage
         uses: actions/upload-artifact@v4
-        if: always()
         with:
           name: Coverage report
           path: app/build/reports/jacoco/jacocoTestReport
-          if-no-files-found: warn
 
+      # Run SonarCloud analysis after coverage generation
       - name: SonarCloud Scan
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         uses: SonarSource/sonarqube-scan-action@v5.0.0
         with:
           args: >


### PR DESCRIPTION
Revert to the original single-job CI that handles all tests and coverage in one job to avoid artifact management issues with SonarCloud analysis. 