### PR TITLE
fix(serie): fix return when when checking an empty expired Serie

### DIFF
--- a/app/src/main/java/com/android/joinme/model/serie/Serie.kt
+++ b/app/src/main/java/com/android/joinme/model/serie/Serie.kt
@@ -83,12 +83,12 @@ fun Serie.isActive(events: List<Event>): Boolean {
  * A series is considered expired if all its events have finished (end time has passed).
  *
  * @param events List of all events to check
- * @return True if all events in the series have finished, false if any event is ongoing or
- *   upcoming, or if the series has no events
+ * @return True if all events in the series have finished or if the series has no events, false if
+ *   any event is ongoing or upcoming
  */
 fun Serie.isExpired(events: List<Event>): Boolean {
   val serieEvents = events.filter { it.eventId in eventIds }
-  if (serieEvents.isEmpty()) return false
+  if (serieEvents.isEmpty()) return true
 
   val now = System.currentTimeMillis()
   return serieEvents.all { event ->

--- a/app/src/test/java/com/android/joinme/model/serie/SerieTest.kt
+++ b/app/src/test/java/com/android/joinme/model/serie/SerieTest.kt
@@ -196,11 +196,11 @@ class SerieTest {
   }
 
   @Test
-  fun `isExpired returns false when serie has no events`() {
+  fun `isExpired returns true when serie has no events`() {
     val serie = sampleSerie.copy(eventIds = emptyList())
     val events = listOf(createEvent("event1", duration = 60, hoursOffset = -5))
 
-    assertFalse(serie.isExpired(events))
+    assertTrue(serie.isExpired(events))
   }
 
   @Test


### PR DESCRIPTION
## Description
The auxiliary function `isExpired` returned false instead of true when there's no events in the serie.

## Changes
- Return false instead of true when there's no events in the serie

## Next
- Update the history to take events and series

## Other
Closes #199 
