### PR TITLE
fix(serie): add spacing after the card and colors for back layers

### DIFF
--- a/app/src/main/java/com/android/joinme/ui/components/SerieCard.kt
+++ b/app/src/main/java/com/android/joinme/ui/components/SerieCard.kt
@@ -1,6 +1,7 @@
 package com.android.joinme.ui.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -30,7 +31,9 @@ import com.android.joinme.model.serie.Serie
 import com.android.joinme.ui.theme.IconColor
 import com.android.joinme.ui.theme.OnEventCardTextColor
 import com.android.joinme.ui.theme.SerieCardBackgroundColor
+import com.android.joinme.ui.theme.SerieCardLayer2BorderColor
 import com.android.joinme.ui.theme.SerieCardLayer2Color
+import com.android.joinme.ui.theme.SerieCardLayer3BorderColor
 import com.android.joinme.ui.theme.SerieCardLayer3Color
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -52,7 +55,7 @@ import java.util.Locale
  */
 @Composable
 fun SerieCard(modifier: Modifier = Modifier, serie: Serie, onClick: () -> Unit, testTag: String) {
-  Box(modifier = modifier.fillMaxWidth()) {
+  Box(modifier = modifier.fillMaxWidth().padding(bottom = 12.dp)) {
     // Third layer (furthest back)
     Box(
         modifier =
@@ -61,7 +64,8 @@ fun SerieCard(modifier: Modifier = Modifier, serie: Serie, onClick: () -> Unit, 
                 .offset(y = 12.dp)
                 .height(100.dp)
                 .clip(RoundedCornerShape(12.dp))
-                .background(SerieCardLayer3Color))
+                .background(SerieCardLayer3Color)
+                .border(2.dp, SerieCardLayer3BorderColor, RoundedCornerShape(12.dp)))
 
     // Second layer (middle)
     Box(
@@ -71,7 +75,8 @@ fun SerieCard(modifier: Modifier = Modifier, serie: Serie, onClick: () -> Unit, 
                 .offset(y = 6.dp)
                 .height(100.dp)
                 .clip(RoundedCornerShape(12.dp))
-                .background(SerieCardLayer2Color))
+                .background(SerieCardLayer2Color)
+                .border(2.dp, SerieCardLayer2BorderColor, RoundedCornerShape(12.dp)))
 
     // Main card (front)
     Card(

--- a/app/src/main/java/com/android/joinme/ui/theme/Color.kt
+++ b/app/src/main/java/com/android/joinme/ui/theme/Color.kt
@@ -23,6 +23,8 @@ val SocialColor = Color(0xFFE57373) // Red for SOCIAL
 val SerieCardBackgroundColor = Color(0xFF2D2D3D)
 val SerieCardLayer2Color = Color(0xFF232333)
 val SerieCardLayer3Color = Color(0xFF1A1A24)
+val SerieCardLayer2BorderColor = Color(0xFF7E57C2) // Purple border for second layer
+val SerieCardLayer3BorderColor = Color(0xFF5E35B1) // Darker purple for third layer
 
 // Common UI colors
 val DarkButtonColor = Color(0xFF1C1C1E)


### PR DESCRIPTION
## Description
There wasn't enough spacing after a SerieCard. This PR adds spacing, and also outline colors for the back layers.

## Changes
- Add padding to the card

## Screenshots
<img width="200" height="500" alt="image" src="https://github.com/user-attachments/assets/f81126ac-d262-4d8a-aa42-cda2e0403852" />


## Other
Closes #201 