### PR TITLE
fix(ci): update timeout for instrumented tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
           fi
 
       - name: Run instrumentation tests
-        timeout-minutes: 25
+        timeout-minutes: 45
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34


### PR DESCRIPTION
## Description

There was a timeout of 25 minutes for instrumented tests in CI runner, this was changes to 45 minutes

## Issues
Closes #210 