### PR TITLE
fix: fetching right groups

### DIFF
--- a/app/src/main/java/com/android/joinme/model/groups/GroupRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/joinme/model/groups/GroupRepositoryFirestore.kt
@@ -15,22 +15,18 @@ const val GROUPS_COLLECTION_PATH = "groups"
  * objects.
  */
 class GroupRepositoryFirestore(private val db: FirebaseFirestore) : GroupRepository {
-  private val ownerAttributeName = "ownerId"
 
   override fun getNewGroupId(): String {
     return db.collection(GROUPS_COLLECTION_PATH).document().id
   }
 
   override suspend fun getAllGroups(): List<Group> {
-    val ownerId =
+    val userId =
         Firebase.auth.currentUser?.uid
             ?: throw Exception("GroupRepositoryFirestore: User not logged in.")
 
     val snapshot =
-        db.collection(GROUPS_COLLECTION_PATH)
-            .whereEqualTo(ownerAttributeName, ownerId)
-            .get()
-            .await()
+        db.collection(GROUPS_COLLECTION_PATH).whereArrayContains("memberIds", userId).get().await()
 
     return snapshot.mapNotNull { documentToGroup(it) }
   }

--- a/app/src/test/java/com/android/joinme/repository/GroupRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/joinme/repository/GroupRepositoryFirestoreTest.kt
@@ -151,7 +151,7 @@ class GroupRepositoryFirestoreTest {
     val mockSnapshot1 = mockk<com.google.firebase.firestore.QueryDocumentSnapshot>(relaxed = true)
     val mockSnapshot2 = mockk<com.google.firebase.firestore.QueryDocumentSnapshot>(relaxed = true)
 
-    every { mockCollection.whereEqualTo("ownerId", testUserId) } returns mockQuery
+    every { mockCollection.whereArrayContains("memberIds", testUserId) } returns mockQuery
     every { mockQuery.get() } returns Tasks.forResult(mockQuerySnapshot)
     every { mockQuerySnapshot.iterator() } returns
         mutableListOf(mockSnapshot1, mockSnapshot2).iterator()


### PR DESCRIPTION
- Before we only fetch groups where userId was equal to the owner of the group. Now we fetch all groups where user is in.
- Update tests 