### PR TITLE
feat(event): add EditEventForSerieScreen with tests

### DIFF
--- a/app/src/main/java/com/android/joinme/ui/overview/EditEventForSerieScreen.kt
+++ b/app/src/main/java/com/android/joinme/ui/overview/EditEventForSerieScreen.kt
@@ -86,5 +86,5 @@ fun EditEventForSerieScreen(
         success
       },
       onGoBack = onGoBack,
-      saveButtonText = "Save Changes")
+      saveButtonText = "SAVE CHANGES")
 }

--- a/app/src/test/java/com/android/joinme/ui/overview/EditEventForSerieScreenTest.kt
+++ b/app/src/test/java/com/android/joinme/ui/overview/EditEventForSerieScreenTest.kt
@@ -158,7 +158,7 @@ class EditEventForSerieScreenTest {
 
     // Title and button text are correct
     composeTestRule.onNodeWithText("Edit Event for Serie").assertIsDisplayed()
-    composeTestRule.onNodeWithText("Save Changes").assertIsDisplayed()
+    composeTestRule.onNodeWithText("SAVE CHANGES").assertIsDisplayed()
 
     // Fields inherited from serie are not displayed
     composeTestRule


### PR DESCRIPTION
## Description

This PR adds `EditEventForSerieScreen.kt` to allow editing events within a serie.

## Changes

- `EditEventForSerieScreen.kt`:
  - Reuses `EventForSerieFormScreen` composable and `EditEventForSerieViewModel`
  - When duration changes, all subsequent events in the serie are recalculated in the view model

## What's next

Add navigation to the new screen.

## Issue

Closes #261 