### PR TITLE
Fix Join/Quit button in ShowEventScreen for events in a serie

### DIFF
--- a/app/src/main/java/com/android/joinme/model/event/Event.kt
+++ b/app/src/main/java/com/android/joinme/model/event/Event.kt
@@ -26,7 +26,7 @@ data class Event(
     val maxParticipants: Int,
     val visibility: EventVisibility,
     val ownerId: String,
-    val isPartOfASerie: Boolean = false
+    val partOfASerie: Boolean = false
 )
 
 /**

--- a/app/src/main/java/com/android/joinme/model/event/EventsRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/joinme/model/event/EventsRepositoryFirestore.kt
@@ -153,6 +153,8 @@ class EventsRepositoryFirestore(
                 name = it["name"] as? String ?: "")
           }
 
+      val partOfASerie = document.getBoolean("partOfASerie") ?: false
+
       Event(
           eventId = eventId,
           type = EventType.valueOf(typeString),
@@ -164,7 +166,8 @@ class EventsRepositoryFirestore(
           participants = participants,
           maxParticipants = maxParticipants,
           visibility = EventVisibility.valueOf(visibilityString),
-          ownerId = ownerId)
+          ownerId = ownerId,
+          partOfASerie = partOfASerie)
     } catch (e: Exception) {
       null
     }

--- a/app/src/main/java/com/android/joinme/ui/overview/CreateEventForSerieViewModel.kt
+++ b/app/src/main/java/com/android/joinme/ui/overview/CreateEventForSerieViewModel.kt
@@ -110,7 +110,7 @@ class CreateEventForSerieViewModel(
                     com.android.joinme.model.utils.Visibility.PRIVATE -> EventVisibility.PRIVATE
                   },
               ownerId = serie.ownerId, // Inherit from serie
-              isPartOfASerie = true // Mark as part of a serie
+              partOfASerie = true // Mark as part of a serie
               )
 
       // Add the event to the repository

--- a/app/src/main/java/com/android/joinme/ui/overview/ShowEventScreen.kt
+++ b/app/src/main/java/com/android/joinme/ui/overview/ShowEventScreen.kt
@@ -332,7 +332,7 @@ fun ShowEventScreen(
                       }
                 } else {
                   // if event is part of a serie, don't display join/quit button
-                  if (!eventUIState.isPartOfASerie) {
+                  if (!eventUIState.partOfASerie) {
                     // if event is full, don't display join button
                     val participantCount = eventUIState.participantsCount.toIntOrNull() ?: 0
                     val maxParticipants =

--- a/app/src/main/java/com/android/joinme/ui/overview/ShowEventViewModel.kt
+++ b/app/src/main/java/com/android/joinme/ui/overview/ShowEventViewModel.kt
@@ -31,7 +31,7 @@ data class ShowEventUIState(
     val ownerName: String = "",
     val participants: List<String> = emptyList(),
     val isPastEvent: Boolean = false,
-    val isPartOfASerie: Boolean = false,
+    val partOfASerie: Boolean = false,
     val serieId: String? = null,
     val errorMsg: String? = null,
 ) {
@@ -109,7 +109,7 @@ class ShowEventViewModel(
                 ownerName = ownerDisplayName,
                 participants = event.participants,
                 isPastEvent = isPast,
-                isPartOfASerie = event.isPartOfASerie,
+                partOfASerie = event.partOfASerie,
                 serieId = serieId)
       } catch (e: Exception) {
         setErrorMsg("Failed to load Event: ${e.message}")

--- a/app/src/test/java/com/android/joinme/model/event/EventTest.kt
+++ b/app/src/test/java/com/android/joinme/model/event/EventTest.kt
@@ -113,18 +113,18 @@ class EventTest {
   }
 
   @Test
-  fun `isPartOfASerie defaults to false`() {
-    assertFalse(sampleEvent.isPartOfASerie)
+  fun `partOfASerie defaults to false`() {
+    assertFalse(sampleEvent.partOfASerie)
   }
 
   @Test
   fun `event can be part of a serie`() {
-    val serieEvent = sampleEvent.copy(isPartOfASerie = true)
-    assertTrue(serieEvent.isPartOfASerie)
+    val serieEvent = sampleEvent.copy(partOfASerie = true)
+    assertTrue(serieEvent.partOfASerie)
   }
 
   @Test
-  fun `isPartOfASerie property is correctly set`() {
+  fun `partOfASerie property is correctly set`() {
     val standaloneEvent =
         Event(
             eventId = "456",
@@ -138,7 +138,7 @@ class EventTest {
             maxParticipants = 15,
             visibility = EventVisibility.PRIVATE,
             ownerId = "owner456",
-            isPartOfASerie = false)
+            partOfASerie = false)
 
     val serieEvent =
         Event(
@@ -153,9 +153,9 @@ class EventTest {
             maxParticipants = 8,
             visibility = EventVisibility.PUBLIC,
             ownerId = "owner789",
-            isPartOfASerie = true)
+            partOfASerie = true)
 
-    assertFalse(standaloneEvent.isPartOfASerie)
-    assertTrue(serieEvent.isPartOfASerie)
+    assertFalse(standaloneEvent.partOfASerie)
+    assertTrue(serieEvent.partOfASerie)
   }
 }


### PR DESCRIPTION
 ## Summary
  Fixes #308 - Join/Quit button incorrectly appearing for events in a series

  ## Problem
  The Join/Quit button was showing for events that are part of a series, even though users should only join/quit the
   entire series, not individual events.

  The root cause was that the `isPartOfASerie` boolean field was not being properly serialized/deserialized by
  Firebase. Kotlin's boolean property naming conventions with the "is" prefix caused Firebase to handle the field
  inconsistently, resulting in events always having `isPartOfASerie = false` even when they were created with
  `true`.

  Last time I fixed this bug and was working on my machine but then when events were fetched from Firestore the field isPartOfASerie was incorrect but this time this is working.

To see the change, you need to create a **new** serie so that the field partOfASerie is correct in Firestore.

  ## Solution
  - Renamed `isPartOfASerie` to `partOfASerie` throughout the codebase
  - Updated all references in Event model, ViewModels, UI components, and tests
  - Firebase now correctly saves and retrieves the `partOfASerie` field
  - Join/Quit button is now properly hidden for events that are part of a series

  ## Test Plan
No new tests added, only refactor the ones with isPartOfASerie to partOfASerie