### PR TITLE
Feature/chat notification

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -380,13 +380,13 @@ export const cleanupOldEventsAndSeries = functions.pubsub
  * Triggered when a new message is created in a group chat.
  * Sends push notifications to all group members except the sender.
  */
-export const onChatMessageCreated = functions.firestore
-  .document("conversations/{conversationId}/messages/{messageId}")
+export const onChatMessageCreated = functions.database
+  .ref("conversations/{conversationId}/messages/{messageId}")
   .onCreate(async (snapshot, context) => {
     try {
       const conversationId = context.params.conversationId;
       const messageId = context.params.messageId;
-      const messageData = snapshot.data();
+      const messageData = snapshot.val();
 
       console.log(`New message in conversation ${conversationId}`);
 


### PR DESCRIPTION
Added Firebase Cloud Function to send push notifications to group members when new chat messages are sent.

![tempFileForShare_20251119-135621](https://github.com/user-attachments/assets/89780ae3-d92a-4ece-9d86-8f81385e3f60)


Added `onChatMessageCreated` Cloud Function in `functions/src/index.ts`
- Triggers when a new message is created in `conversations/{conversationId}/messages/{messageId}`
- Fetches group members from the group document (using `conversationId` = `groupId`)
- Sends FCM notifications to all group members except the sender
- Skips notifications for system messages (e.g., "User joined")
- Truncates long messages to 100 characters in notifications

Issue #326 