### PR TITLE
Feature/event for group view model

### DIFF
--- a/app/src/main/java/com/android/joinme/ui/overview/CreateEventViewModel.kt
+++ b/app/src/main/java/com/android/joinme/ui/overview/CreateEventViewModel.kt
@@ -79,8 +79,7 @@ data class CreateEventUIState(
 class CreateEventViewModel(
     private val repository: EventsRepository =
         EventsRepositoryProvider.getRepository(isOnline = true),
-    private val groupRepository: GroupRepository =
-        GroupRepositoryProvider.repository,
+    private val groupRepository: GroupRepository = GroupRepositoryProvider.repository,
     locationRepository: LocationRepository = NominatimLocationRepository(HttpClientProvider.client)
 ) : BaseEventFormViewModel(locationRepository) {
 

--- a/app/src/test/java/com/android/joinme/ui/overview/CreateEventViewModelTest.kt
+++ b/app/src/test/java/com/android/joinme/ui/overview/CreateEventViewModelTest.kt
@@ -330,8 +330,7 @@ class CreateEventViewModelTest {
     // Try to set maxParticipants less than group size
     newVm.setMaxParticipants("3")
     Assert.assertNotNull(newVm.uiState.value.invalidMaxParticipantsMsg)
-    Assert.assertTrue(
-        newVm.uiState.value.invalidMaxParticipantsMsg!!.contains("at least 5"))
+    Assert.assertTrue(newVm.uiState.value.invalidMaxParticipantsMsg!!.contains("at least 5"))
 
     // Set maxParticipants equal to group size
     newVm.setMaxParticipants("5")


### PR DESCRIPTION
## Description

Extended CreateEventViewModel to support creating events that belong to a group, in addition to standalone events. When creating an event for a group, the event ID is automatically added to the group's eventIds list.

## Changes

  **CreateEventUIState**:
  - Added selectedGroupId: String? - tracks the selected group (null for standalone events)
  - Added availableGroups: List<Group> - stores user's groups loaded on initialization

  **CreateEventViewModel**:
  - Added GroupRepository dependency injection
  - Added loadUserGroups() - fetches user's groups on ViewModel initialization (fails gracefully)
  - Added setSelectedGroup(groupId: String?) - updates selected group and re-validates maxParticipants
  - Updated setMaxParticipants() - validates that maxParticipants >= group size when a group is selected
  - Updated createEvent():
    - Fetches group once (optimized) for both getting members and updating event list
    - Adds all group members as initial participants when creating event for a group
    - Adds event ID to group's eventIds list
    - Fails if selected group doesn't exist (prevents creating orphaned events)

  **Validation**:
  - MaxParticipants must be >= group member count when a group is selected
  - Validation automatically updates when switching between groups or clearing group selection
  - Error message: "Must be at least X (group size)"

## Next
Update `CreateEventScreen` to add a dropdown for selecting a group.

## Issue
Closes #334 

Note: This description was co-written with AI (Claude).