### PR TITLE
fix: 5 SonarCloud Critical issues related to duplicated literals.

### DIFF
--- a/app/src/main/java/com/android/joinme/MainActivity.kt
+++ b/app/src/main/java/com/android/joinme/MainActivity.kt
@@ -64,6 +64,14 @@ object HttpClientProvider {
   var client: OkHttpClient = OkHttpClient()
 }
 
+/** Exception message for when a serie ID is null. */
+const val SERIES_ID_NULL = "Serie ID is null"
+
+/** Key for the series ID in the bundle. */
+const val SERIES_ID = "serieId"
+
+/** Key for the event ID in the bundle. */
+const val EVENT_ID = "eventId"
 /**
  * MainActivity is the single activity for the JoinMe application.
  *
@@ -236,17 +244,17 @@ fun JoinMe(
             onGoBack = { navigationActions.goBack() })
       }
       composable(Screen.CreateEventForSerie.route) { navBackStackEntry ->
-        val serieId = navBackStackEntry.arguments?.getString("serieId")
+        val serieId = navBackStackEntry.arguments?.getString(SERIES_ID)
 
         serieId?.let {
           CreateEventForSerieScreen(
               serieId = serieId,
               onDone = { navigationActions.navigateTo(Screen.Overview) },
               onGoBack = { navigationActions.goBack() })
-        } ?: run { Toast.makeText(context, "Serie ID is null", Toast.LENGTH_SHORT).show() }
+        } ?: run { Toast.makeText(context, SERIES_ID_NULL, Toast.LENGTH_SHORT).show() }
       }
       composable(Screen.EditEvent.route) { navBackStackEntry ->
-        val eventId = navBackStackEntry.arguments?.getString("eventId")
+        val eventId = navBackStackEntry.arguments?.getString(EVENT_ID)
 
         eventId?.let {
           EditEventScreen(
@@ -262,8 +270,8 @@ fun JoinMe(
             onGoBack = { navigationActions.goBack() })
       }
       composable(Screen.ShowEventScreen.route) { navBackStackEntry ->
-        val eventId = navBackStackEntry.arguments?.getString("eventId")
-        val serieId = navBackStackEntry.arguments?.getString("serieId")
+        val eventId = navBackStackEntry.arguments?.getString(EVENT_ID)
+        val serieId = navBackStackEntry.arguments?.getString(SERIES_ID)
 
         eventId?.let {
           ShowEventScreen(
@@ -280,7 +288,7 @@ fun JoinMe(
         } ?: run { Toast.makeText(context, "Event UID is null", Toast.LENGTH_SHORT).show() }
       }
       composable(Screen.SerieDetails.route) { navBackStackEntry ->
-        val serieId = navBackStackEntry.arguments?.getString("serieId")
+        val serieId = navBackStackEntry.arguments?.getString(SERIES_ID)
 
         serieId?.let {
           SerieDetailsScreen(
@@ -294,32 +302,32 @@ fun JoinMe(
               },
               onEditSerieClick = { id -> navigationActions.navigateTo(Screen.EditSerie(id)) },
               onQuitSerieSuccess = { navigationActions.goBack() })
-        } ?: run { Toast.makeText(context, "Serie ID is null", Toast.LENGTH_SHORT).show() }
+        } ?: run { Toast.makeText(context, SERIES_ID_NULL, Toast.LENGTH_SHORT).show() }
       }
       composable(Screen.EditSerie.route) { navBackStackEntry ->
-        val serieId = navBackStackEntry.arguments?.getString("serieId")
+        val serieId = navBackStackEntry.arguments?.getString(SERIES_ID)
 
         serieId?.let {
           EditSerieScreen(
               serieId = serieId,
               onGoBack = { navigationActions.goBack() },
               onDone = { navigationActions.navigateTo(Screen.Overview) })
-        } ?: run { Toast.makeText(context, "Serie ID is null", Toast.LENGTH_SHORT).show() }
+        } ?: run { Toast.makeText(context, SERIES_ID_NULL, Toast.LENGTH_SHORT).show() }
       }
       composable(Screen.CreateEventForSerie.route) { navBackStackEntry ->
-        val serieId = navBackStackEntry.arguments?.getString("serieId")
+        val serieId = navBackStackEntry.arguments?.getString(SERIES_ID)
 
         serieId?.let {
           CreateEventForSerieScreen(
               serieId = serieId,
               onDone = { navigationActions.navigateTo(Screen.Overview) },
               onGoBack = { navigationActions.goBack() })
-        } ?: run { Toast.makeText(context, "Serie ID is null", Toast.LENGTH_SHORT).show() }
+        } ?: run { Toast.makeText(context, SERIES_ID_NULL, Toast.LENGTH_SHORT).show() }
       }
 
       composable(Screen.EditEventForSerie.route) { navBackStackEntry ->
-        val serieId = navBackStackEntry.arguments?.getString("serieId")
-        val eventId = navBackStackEntry.arguments?.getString("eventId")
+        val serieId = navBackStackEntry.arguments?.getString(SERIES_ID)
+        val eventId = navBackStackEntry.arguments?.getString(EVENT_ID)
 
         if (serieId != null && eventId != null) {
           EditEventForSerieScreen(

--- a/app/src/main/java/com/android/joinme/model/chat/ChatRepositoryLocal.kt
+++ b/app/src/main/java/com/android/joinme/model/chat/ChatRepositoryLocal.kt
@@ -8,6 +8,9 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
+/** Exception message for when a message is not found in the local repository. */
+const val MESSAGE_NOT_FOUND = "ChatRepositoryLocal: Message not found"
+
 /**
  * In-memory implementation of [ChatRepository] for offline mode or testing.
  *
@@ -48,7 +51,7 @@ class ChatRepositoryLocal : ChatRepository {
         messages[index] = newValue
         messagesFlow.value = messages.toList()
       } else {
-        throw Exception("ChatRepositoryLocal: Message not found")
+        throw Exception(MESSAGE_NOT_FOUND)
       }
     }
   }
@@ -61,7 +64,7 @@ class ChatRepositoryLocal : ChatRepository {
         messages.removeAt(index)
         messagesFlow.value = messages.toList()
       } else {
-        throw Exception("ChatRepositoryLocal: Message not found")
+        throw Exception(MESSAGE_NOT_FOUND)
       }
     }
   }
@@ -81,7 +84,7 @@ class ChatRepositoryLocal : ChatRepository {
           messagesFlow.value = messages.toList()
         }
       } else {
-        throw Exception("ChatRepositoryLocal: Message not found")
+        throw Exception(MESSAGE_NOT_FOUND)
       }
     }
   }

--- a/app/src/main/java/com/android/joinme/model/event/EventsRepositoryLocal.kt
+++ b/app/src/main/java/com/android/joinme/model/event/EventsRepositoryLocal.kt
@@ -1,5 +1,8 @@
 package com.android.joinme.model.event
 
+/** Exception message for when an event is not found in the local repository. */
+const val EVENT_NOT_FOUND = "EventsRepositoryLocal: Event not found"
+
 /** Represents a repository that manages a local list of events (for offline mode or testing). */
 class EventsRepositoryLocal : EventsRepository {
   private val events: MutableList<Event> = mutableListOf()
@@ -14,8 +17,7 @@ class EventsRepositoryLocal : EventsRepository {
   }
 
   override suspend fun getEvent(eventId: String): Event {
-    return events.find { it.eventId == eventId }
-        ?: throw Exception("EventsRepositoryLocal: Event not found")
+    return events.find { it.eventId == eventId } ?: throw Exception(EVENT_NOT_FOUND)
   }
 
   override suspend fun addEvent(event: Event) {
@@ -33,7 +35,7 @@ class EventsRepositoryLocal : EventsRepository {
     if (index != -1) {
       events[index] = newValue
     } else {
-      throw Exception("EventsRepositoryLocal: Event not found")
+      throw Exception(EVENT_NOT_FOUND)
     }
   }
 
@@ -42,7 +44,7 @@ class EventsRepositoryLocal : EventsRepository {
     if (index != -1) {
       events.removeAt(index)
     } else {
-      throw Exception("EventsRepositoryLocal: Event not found")
+      throw Exception(EVENT_NOT_FOUND)
     }
   }
 

--- a/app/src/main/java/com/android/joinme/model/groups/GroupRepositoryLocal.kt
+++ b/app/src/main/java/com/android/joinme/model/groups/GroupRepositoryLocal.kt
@@ -1,6 +1,8 @@
 // Implemented with help of Claude AI
 package com.android.joinme.model.groups
 
+/** Exception message for when a group is not found in the local repository. */
+const val GROUP_NOT_FOUND = "GroupRepositoryLocal: Group not found"
 /** Represents a repository that manages a local list of groups (for offline mode or testing). */
 class GroupRepositoryLocal : GroupRepository {
   private val groups: MutableList<Group> = mutableListOf()
@@ -15,8 +17,7 @@ class GroupRepositoryLocal : GroupRepository {
   }
 
   override suspend fun getGroup(groupId: String): Group {
-    return groups.find { it.id == groupId }
-        ?: throw Exception("GroupRepositoryLocal: Group not found")
+    return groups.find { it.id == groupId } ?: throw Exception(GROUP_NOT_FOUND)
   }
 
   override suspend fun addGroup(group: Group) {
@@ -28,7 +29,7 @@ class GroupRepositoryLocal : GroupRepository {
     if (index != -1) {
       groups[index] = newValue
     } else {
-      throw Exception("GroupRepositoryLocal: Group not found")
+      throw Exception(GROUP_NOT_FOUND)
     }
   }
 
@@ -43,7 +44,7 @@ class GroupRepositoryLocal : GroupRepository {
     if (index != -1) {
       groups.removeAt(index)
     } else {
-      throw Exception("GroupRepositoryLocal: Group not found")
+      throw Exception(GROUP_NOT_FOUND)
     }
   }
 

--- a/app/src/main/java/com/android/joinme/model/serie/SeriesRepositoryLocal.kt
+++ b/app/src/main/java/com/android/joinme/model/serie/SeriesRepositoryLocal.kt
@@ -3,6 +3,9 @@ package com.android.joinme.model.serie
 import com.android.joinme.model.event.EventsRepository
 import com.android.joinme.model.event.EventsRepositoryLocal
 
+/** Exception message for when a serie is not found in the local repository. */
+const val SERIES_NOT_FOUND = "SeriesRepositoryLocal: Serie not found"
+
 /**
  * Local in-memory implementation of SeriesRepository.
  *
@@ -48,8 +51,7 @@ class SeriesRepositoryLocal(
    * @throws Exception if the Serie item is not found in local storage
    */
   override suspend fun getSerie(serieId: String): Serie {
-    return series.find { it.serieId == serieId }
-        ?: throw Exception("SeriesRepositoryLocal: Serie not found")
+    return series.find { it.serieId == serieId } ?: throw Exception(SERIES_NOT_FOUND)
   }
 
   /**
@@ -75,7 +77,7 @@ class SeriesRepositoryLocal(
     if (index != -1) {
       series[index] = newValue
     } else {
-      throw Exception("SeriesRepositoryLocal: Serie not found")
+      throw Exception(SERIES_NOT_FOUND)
     }
   }
 
@@ -96,7 +98,7 @@ class SeriesRepositoryLocal(
     if (index != -1) {
       series.removeAt(index)
     } else {
-      throw Exception("SeriesRepositoryLocal: Serie not found")
+      throw Exception(SERIES_NOT_FOUND)
     }
   }
 


### PR DESCRIPTION
  # Summary
  - **MainActivity.kt**: Extract `SERIES_ID_NULL`, `SERIES_ID`, `EVENT_ID` constants
  - **ChatRepositoryLocal.kt**: Extract `MESSAGE_NOT_FOUND` constant (3 duplications)
  - **EventsRepositoryLocal.kt**: Extract `EVENT_NOT_FOUND` constant (3 duplications)
  - **GroupRepositoryLocal.kt**: Extract `GROUP_NOT_FOUND` constant (3 duplications)
  - **SeriesRepositoryLocal.kt**: Extract `SERIES_NOT_FOUND` constant (3 duplications)

Time: 60 min