### PR TITLE
fix/chat-topbar-keyboard-visibility

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,7 +29,8 @@
             android:exported="true"
             android:label="@string/title_activity_main"
             android:theme="@style/Theme.SampleApp"
-            android:launchMode="singleTop">
+            android:launchMode="singleTop"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/android/joinme/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/android/joinme/ui/chat/ChatScreen.kt
@@ -9,12 +9,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
@@ -160,6 +161,7 @@ fun ChatScreen(
             onTopBarColor = effectiveOnChatColor)
       },
       snackbarHost = { SnackbarHost(snackbarHostState) },
+      contentWindowInsets = WindowInsets.systemBars, // Only consume system bars, not IME
       containerColor = MaterialTheme.colorScheme.background) { paddingValues ->
         if (uiState.isLoading) {
           Box(
@@ -266,55 +268,48 @@ private fun ChatContent(
     }
   }
 
-  Column(
-      modifier =
-          Modifier.fillMaxSize()
-              .padding(paddingValues)
-              .imePadding() // Push content up when keyboard appears
-      ) {
-        // Messages list
-        LazyColumn(
-            modifier = Modifier.weight(1f).fillMaxWidth().testTag(ChatScreenTestTags.MESSAGE_LIST),
-            state = listState,
-            contentPadding = PaddingValues(Dimens.Padding.medium),
-            verticalArrangement = Arrangement.spacedBy(Dimens.Spacing.itemSpacing)) {
-              if (messages.isEmpty()) {
-                item {
-                  Box(
-                      modifier = Modifier.fillParentMaxSize(),
-                      contentAlignment = Alignment.Center) {
-                        Text(
-                            text = "No messages yet. Start the conversation!",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            textAlign = TextAlign.Center,
-                            modifier = Modifier.testTag(ChatScreenTestTags.EMPTY_MESSAGE))
-                      }
-                }
-              } else {
-                items(messages, key = { it.id }) { message ->
-                  MessageItem(
-                      message = message,
-                      isCurrentUser = message.senderId == currentUserId,
-                      bubbleColor = chatColor,
-                      onBubbleColor = onChatColor)
-                }
+  Column(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+    // Messages list
+    LazyColumn(
+        modifier = Modifier.weight(1f).fillMaxWidth().testTag(ChatScreenTestTags.MESSAGE_LIST),
+        state = listState,
+        contentPadding = PaddingValues(Dimens.Padding.medium),
+        verticalArrangement = Arrangement.spacedBy(Dimens.Spacing.itemSpacing)) {
+          if (messages.isEmpty()) {
+            item {
+              Box(modifier = Modifier.fillParentMaxSize(), contentAlignment = Alignment.Center) {
+                Text(
+                    text = "No messages yet. Start the conversation!",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.testTag(ChatScreenTestTags.EMPTY_MESSAGE))
               }
             }
+          } else {
+            items(messages, key = { it.id }) { message ->
+              MessageItem(
+                  message = message,
+                  isCurrentUser = message.senderId == currentUserId,
+                  bubbleColor = chatColor,
+                  onBubbleColor = onChatColor)
+            }
+          }
+        }
 
-        // Message input
-        MessageInput(
-            text = messageText,
-            onTextChange = { messageText = it },
-            onSendClick = {
-              if (messageText.isNotBlank()) {
-                onSendMessage(messageText)
-                messageText = ""
-              }
-            },
-            sendButtonColor = chatColor,
-            onSendButtonColor = onChatColor)
-      }
+    // Message input
+    MessageInput(
+        text = messageText,
+        onTextChange = { messageText = it },
+        onSendClick = {
+          if (messageText.isNotBlank()) {
+            onSendMessage(messageText)
+            messageText = ""
+          }
+        },
+        sendButtonColor = chatColor,
+        onSendButtonColor = onChatColor)
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes #323 

This PR resolves the issue where the top app bar was being partially or fully hidden when the keyboard opened in the chat screen. The top bar now remains visible and fixed at the top of the screen at all times, regardless of keyboard state.

## Changes Made
- Updated `AndroidManifest.xml` to set `android:windowSoftInputMode="adjustResize"` for the main activity
- Modified `ChatScreen.kt` Scaffold configuration to set `contentWindowInsets = WindowInsets.systemBars`

These changes ensure that:
1. The window resizes when the keyboard appears, moving the input bar above the keyboard
2. The Scaffold only consumes system bar insets (status bar, navigation bar), not keyboard insets
3. The top app bar remains visible and fixed at the top of the screen

## Testing

### Before

https://github.com/user-attachments/assets/e4f02e67-3d67-429a-a19d-43e67cd9cf7d

### After

https://github.com/user-attachments/assets/b9a101c2-37ae-4f24-a555-1f71ab52c4c4

## Related Issues
Closes #323

---

**P.S.** This PR description was written with assistance from Claude AI.