### PR TITLE
feat(group): add groupId in Event and Serie data classes

### DIFF
--- a/app/src/main/java/com/android/joinme/model/event/Event.kt
+++ b/app/src/main/java/com/android/joinme/model/event/Event.kt
@@ -26,7 +26,8 @@ data class Event(
     val maxParticipants: Int,
     val visibility: EventVisibility,
     val ownerId: String,
-    val partOfASerie: Boolean = false
+    val partOfASerie: Boolean = false,
+    val groupId: String? = null
 )
 
 /**

--- a/app/src/main/java/com/android/joinme/model/serie/Serie.kt
+++ b/app/src/main/java/com/android/joinme/model/serie/Serie.kt
@@ -28,6 +28,7 @@ private const val MILLIS_PER_MINUTE = 60_000L
  * @property lastEventEndTime The end time of the last event in the series. Used for optimization to
  *   check if series is expired without loading all events. This is managed internally by the
  *   repository and should not be set manually.
+ * @property groupId Optional ID of the group this series belongs to. Null for standalone series.
  */
 data class Serie
 internal constructor(
@@ -41,6 +42,7 @@ internal constructor(
     val eventIds: List<String>,
     val ownerId: String,
     val lastEventEndTime: Timestamp? = null,
+    val groupId: String? = null,
 ) {
   companion object {
     /**
@@ -55,6 +57,7 @@ internal constructor(
      * @param visibility Visibility setting for events in this series (public or private)
      * @param eventIds List of event IDs belonging to this series
      * @param ownerId User ID of the series creator/owner
+     * @param groupId Optional ID of the group this series belongs to. Null for standalone series.
      * @return A new Serie instance with lastEventEndTime initialized to the serie's start date
      */
     @JvmStatic
@@ -68,6 +71,7 @@ internal constructor(
         visibility: Visibility,
         eventIds: List<String>,
         ownerId: String,
+        groupId: String? = null,
     ): Serie {
       return Serie(
           serieId = serieId,
@@ -79,7 +83,8 @@ internal constructor(
           visibility = visibility,
           eventIds = eventIds,
           ownerId = ownerId,
-          lastEventEndTime = date)
+          lastEventEndTime = date,
+          groupId = groupId)
     }
   }
 }

--- a/app/src/test/java/com/android/joinme/model/event/EventTest.kt
+++ b/app/src/test/java/com/android/joinme/model/event/EventTest.kt
@@ -158,4 +158,70 @@ class EventTest {
     assertFalse(standaloneEvent.partOfASerie)
     assertTrue(serieEvent.partOfASerie)
   }
+
+  @Test
+  fun `groupId property works correctly for all cases`() {
+    // Default to null
+    assertEquals(null, sampleEvent.groupId)
+
+    // Can be set via copy
+    val groupEvent = sampleEvent.copy(groupId = "group123")
+    assertEquals("group123", groupEvent.groupId)
+
+    // Standalone event with null groupId
+    val standaloneEvent =
+        Event(
+            eventId = "456",
+            type = EventType.SOCIAL,
+            title = "Bar Night",
+            description = "Casual bar outing",
+            location = sampleLocation,
+            date = sampleTimestamp,
+            duration = 120,
+            participants = listOf("Charlie", "Dave"),
+            maxParticipants = 15,
+            visibility = EventVisibility.PRIVATE,
+            ownerId = "owner456",
+            partOfASerie = false,
+            groupId = null)
+
+    // Event with explicit groupId
+    val explicitGroupEvent =
+        Event(
+            eventId = "789",
+            type = EventType.ACTIVITY,
+            title = "Group Bowling",
+            description = "Group bowling session",
+            location = sampleLocation,
+            date = sampleTimestamp,
+            duration = 90,
+            participants = listOf("Eve", "Frank"),
+            maxParticipants = 8,
+            visibility = EventVisibility.PRIVATE,
+            ownerId = "owner789",
+            partOfASerie = false,
+            groupId = "group456")
+
+    // Event belonging to both serie and group
+    val serieGroupEvent =
+        Event(
+            eventId = "999",
+            type = EventType.SPORTS,
+            title = "Team Training",
+            description = "Weekly training session",
+            location = sampleLocation,
+            date = sampleTimestamp,
+            duration = 120,
+            participants = listOf("Alice", "Bob", "Charlie"),
+            maxParticipants = 20,
+            visibility = EventVisibility.PRIVATE,
+            ownerId = "owner999",
+            partOfASerie = true,
+            groupId = "group789")
+
+    assertEquals(null, standaloneEvent.groupId)
+    assertEquals("group456", explicitGroupEvent.groupId)
+    assertTrue(serieGroupEvent.partOfASerie)
+    assertEquals("group789", serieGroupEvent.groupId)
+  }
 }

--- a/app/src/test/java/com/android/joinme/model/serie/SerieTest.kt
+++ b/app/src/test/java/com/android/joinme/model/serie/SerieTest.kt
@@ -492,4 +492,76 @@ class SerieTest {
     assertTrue(serieWithNoParticipants.participants.isEmpty())
     assertEquals(0, serieWithNoParticipants.participants.size)
   }
+
+  @Test
+  fun `groupId property works correctly for all cases`() {
+    // Default to null
+    assertEquals(null, sampleSerie.groupId)
+
+    // Can be set via copy
+    val copiedGroupSerie = sampleSerie.copy(groupId = "group123")
+    assertEquals("group123", copiedGroupSerie.groupId)
+
+    // Standalone serie with null groupId
+    val standaloneSerie =
+        Serie(
+            serieId = "serie456",
+            title = "Standalone Serie",
+            description = "Individual serie",
+            date = sampleTimestamp,
+            participants = listOf("user1"),
+            maxParticipants = 10,
+            visibility = Visibility.PUBLIC,
+            eventIds = listOf("event1"),
+            ownerId = "owner456",
+            groupId = null)
+
+    // Serie with explicit groupId
+    val groupSerie =
+        Serie(
+            serieId = "serie789",
+            title = "Group Serie",
+            description = "Team serie",
+            date = sampleTimestamp,
+            participants = listOf("user1", "user2", "user3"),
+            maxParticipants = 20,
+            visibility = Visibility.PRIVATE,
+            eventIds = listOf("event1", "event2"),
+            ownerId = "owner789",
+            groupId = "group456")
+
+    // Test invoke operator with groupId
+    val testDate = Timestamp(Date())
+    val invokedGroupSerie =
+        Serie.invoke(
+            serieId = "test999",
+            title = "Test Group Serie",
+            description = "Test Description",
+            date = testDate,
+            participants = listOf("user1", "user2"),
+            maxParticipants = 15,
+            visibility = Visibility.PRIVATE,
+            eventIds = listOf("event1", "event2"),
+            ownerId = "owner999",
+            groupId = "group999")
+
+    // Test invoke operator without groupId (defaults to null)
+    val invokedStandaloneSerie =
+        Serie.invoke(
+            serieId = "test888",
+            title = "Test Standalone Serie",
+            description = "Test Description",
+            date = testDate,
+            participants = listOf("user1"),
+            maxParticipants = 10,
+            visibility = Visibility.PUBLIC,
+            eventIds = listOf("event1"),
+            ownerId = "owner888")
+
+    // Assertions
+    assertEquals(null, standaloneSerie.groupId)
+    assertEquals("group456", groupSerie.groupId)
+    assertEquals("group999", invokedGroupSerie.groupId)
+    assertEquals(null, invokedStandaloneSerie.groupId)
+  }
 }


### PR DESCRIPTION
## Description

This PR a adds a parameter `groupId` in `Event`and `Serie` data classes. This will facilitate the implementation of events and series for groups.

## Changes

- Add groupId field `Event`and `Serie` data classes.

## Issue
Closes #379