### PR TITLE
fix: centralization on user on first launch of map

### DIFF
--- a/app/src/main/java/com/android/joinme/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/android/joinme/ui/map/MapViewModel.kt
@@ -126,6 +126,13 @@ class MapViewModel(
   private fun startLocationUpdates() {
     locationService?.let { service ->
       viewModelScope.launch {
+        // First, try to get the last known location for immediate initial centering
+        val lastKnownLocation = service.getCurrentLocation()
+        if (lastKnownLocation != null) {
+          _uiState.value = _uiState.value.copy(userLocation = lastKnownLocation)
+        }
+
+        // Then start continuous location updates
         service.getUserLocationFlow().filterNotNull().collect { location ->
           _uiState.value = _uiState.value.copy(userLocation = location)
         }


### PR DESCRIPTION
# Summary
When the app it was launch for the first time, the centralization did not work properly for the first time accessing the map. Now it is fixed. 

## How to see if the bug is not here.
- Launch the emulator in cold boot.
- Launch the app and navigate to the map.

## How it is fixed 
  - Move location service initialization to trigger after permission grant
  - Fetch last known location immediately to center the map without delay
  - Improve error handling in camera animation