### PR TITLE
feat(group): update EditEvent for groups

### DIFF
--- a/app/src/main/java/com/android/joinme/model/event/EventsRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/joinme/model/event/EventsRepositoryFirestore.kt
@@ -183,6 +183,7 @@ class EventsRepositoryFirestore(
           }
 
       val partOfASerie = document.getBoolean("partOfASerie") ?: false
+      val groupId = document.getString("groupId")
 
       Event(
           eventId = eventId,
@@ -196,7 +197,8 @@ class EventsRepositoryFirestore(
           maxParticipants = maxParticipants,
           visibility = EventVisibility.valueOf(visibilityString),
           ownerId = ownerId,
-          partOfASerie = partOfASerie)
+          partOfASerie = partOfASerie,
+          groupId = groupId)
     } catch (e: Exception) {
       null
     }

--- a/app/src/main/java/com/android/joinme/ui/overview/CreateEventViewModel.kt
+++ b/app/src/main/java/com/android/joinme/ui/overview/CreateEventViewModel.kt
@@ -172,7 +172,9 @@ class CreateEventViewModel(
             participants = selectedGroup?.memberIds ?: emptyList(),
             maxParticipants = state.maxParticipants.toInt(),
             visibility = EventVisibility.valueOf(state.visibility.uppercase(Locale.ROOT)),
-            ownerId = ownerId)
+            ownerId = ownerId,
+            partOfASerie = false,
+            groupId = state.selectedGroupId) // Set groupId to track group membership
 
     // Fetch owner profile first to validate it exists
     val ownerProfile =

--- a/app/src/main/java/com/android/joinme/ui/overview/EditEventScreen.kt
+++ b/app/src/main/java/com/android/joinme/ui/overview/EditEventScreen.kt
@@ -89,6 +89,8 @@ fun EditEventScreen(
       title = "Edit Event",
       formState = formState,
       testTags = testTags,
+      isGroupEvent =
+          eventUIState.isGroupEvent, // Hide type, maxParticipants, visibility for group events
       onTypeChange = { editEventViewModel.setType(it) },
       onTitleChange = { editEventViewModel.setTitle(it) },
       onDescriptionChange = { editEventViewModel.setDescription(it) },

--- a/app/src/test/java/com/android/joinme/model/event/EventsRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/joinme/model/event/EventsRepositoryFirestoreTest.kt
@@ -108,6 +108,8 @@ class EventsRepositoryFirestoreTest {
     every { mockSnapshot.getString("ownerId") } returns testUserId
     every { mockSnapshot.get("location") } returns
         mapOf("latitude" to 46.52, "longitude" to 6.63, "name" to "EPFL Café")
+    every { mockSnapshot.getBoolean("partOfASerie") } returns false
+    every { mockSnapshot.getString("groupId") } returns "group123"
 
     // When
     val result = repository.getEvent(testEventId)
@@ -118,6 +120,8 @@ class EventsRepositoryFirestoreTest {
     assertEquals("Coffee Meetup", result.title)
     assertEquals(EventType.SOCIAL, result.type)
     assertEquals(testUserId, result.ownerId)
+    assertEquals(false, result.partOfASerie)
+    assertEquals("group123", result.groupId)
   }
 
   @Test
@@ -388,6 +392,8 @@ class EventsRepositoryFirestoreTest {
     every { mockSnapshot.getLong("maxParticipants") } returns null // Should default to 0
     every { mockSnapshot.getString("ownerId") } returns testUserId
     every { mockSnapshot.get("location") } returns null
+    every { mockSnapshot.getBoolean("partOfASerie") } returns null // Should default to false
+    every { mockSnapshot.getString("groupId") } returns null // Should default to null
 
     // When
     val result = repository.getEvent(testEventId)
@@ -400,6 +406,8 @@ class EventsRepositoryFirestoreTest {
     assertEquals(0, result.duration) // Default value
     assertEquals(emptyList<String>(), result.participants) // Default value
     assertEquals(0, result.maxParticipants) // Default value
+    assertEquals(false, result.partOfASerie) // Default value
+    assertEquals(null, result.groupId) // Default value
   }
 
   @Test

--- a/app/src/test/java/com/android/joinme/ui/overview/CreateEventViewModelTest.kt
+++ b/app/src/test/java/com/android/joinme/ui/overview/CreateEventViewModelTest.kt
@@ -621,6 +621,11 @@ class CreateEventViewModelTest {
     Assert.assertTrue(result)
     Assert.assertEquals(1, repo.added.size)
 
+    // Verify event has null groupId for standalone events
+    val createdEvent = repo.added[0]
+    Assert.assertNull(createdEvent.groupId)
+    Assert.assertFalse(createdEvent.partOfASerie)
+
     // Verify profile was updated with incremented count
     verify(profileRepository)
         .createOrUpdateProfile(
@@ -702,6 +707,9 @@ class CreateEventViewModelTest {
     val createdEvent = repo.added[0]
     Assert.assertEquals(3, createdEvent.participants.size)
     Assert.assertTrue(createdEvent.participants.containsAll(listOf("user1", "user2", "user3")))
+
+    // Verify event has groupId set
+    Assert.assertEquals("group-1", createdEvent.groupId)
 
     // Verify group was updated with event ID
     val updatedGroup = groupRepo.getGroup("group-1")

--- a/app/src/test/java/com/android/joinme/ui/overview/EditEventScreenTest.kt
+++ b/app/src/test/java/com/android/joinme/ui/overview/EditEventScreenTest.kt
@@ -611,6 +611,158 @@ class EditEventScreenTest {
         .assertTextContains("PRIVATE")
   }
 
+  /** --- GROUP EVENT TESTS --- */
+  private fun createTestGroupEvent(): Event {
+    val calendar = Calendar.getInstance()
+    calendar.set(2024, Calendar.DECEMBER, 25, 14, 30, 0)
+
+    return Event(
+        eventId = "test-group-event-1",
+        type = EventType.SPORTS,
+        title = "Group Basketball Game",
+        description = "Group event for basketball",
+        location = Location(46.5197, 6.6323, "EPFL"),
+        date = Timestamp(calendar.time),
+        duration = 90,
+        participants = listOf("user1", "user2"),
+        maxParticipants = 10,
+        visibility = EventVisibility.PUBLIC,
+        ownerId = "owner123",
+        groupId = "group-123")
+  }
+
+  @Test
+  fun groupAndStandaloneEvents_loadCorrectGroupIdAndIsGroupEventState() {
+    val repo = EventsRepositoryLocal()
+    val groupEvent = createTestGroupEvent()
+    val standaloneEvent = createTestEvent()
+    runBlocking {
+      repo.addEvent(groupEvent)
+      repo.addEvent(standaloneEvent)
+    }
+
+    // Test group event
+    val groupViewModel = EditEventViewModel(repo, MockLocationRepository())
+    groupViewModel.loadEvent(groupEvent.eventId)
+    composeTestRule.waitForIdle()
+    composeTestRule.mainClock.advanceTimeBy(2000)
+    composeTestRule.waitForIdle()
+
+    assert(groupViewModel.uiState.value.groupId == "group-123")
+    assert(groupViewModel.uiState.value.isGroupEvent)
+
+    // Test standalone event
+    val standaloneViewModel = EditEventViewModel(repo, MockLocationRepository())
+    standaloneViewModel.loadEvent(standaloneEvent.eventId)
+    composeTestRule.waitForIdle()
+    composeTestRule.mainClock.advanceTimeBy(2000)
+    composeTestRule.waitForIdle()
+
+    assert(standaloneViewModel.uiState.value.groupId == null)
+    assert(!standaloneViewModel.uiState.value.isGroupEvent)
+  }
+
+  @Test
+  fun groupEvent_hidesNonEditableFieldsAndShowsEditableFields() {
+    val repo = EventsRepositoryLocal()
+    val groupEvent = createTestGroupEvent()
+    runBlocking { repo.addEvent(groupEvent) }
+    val viewModel = EditEventViewModel(repo, MockLocationRepository())
+
+    composeTestRule.setContent {
+      EditEventScreen(eventId = groupEvent.eventId, editEventViewModel = viewModel, onDone = {})
+    }
+
+    composeTestRule.waitForIdle()
+    composeTestRule.mainClock.advanceTimeBy(2000)
+    composeTestRule.waitForIdle()
+
+    // Verify non-editable fields are hidden
+    composeTestRule.onNodeWithTag(EditEventScreenTestTags.INPUT_EVENT_TYPE).assertDoesNotExist()
+    composeTestRule
+        .onNodeWithTag(EditEventScreenTestTags.INPUT_EVENT_MAX_PARTICIPANTS)
+        .assertDoesNotExist()
+    composeTestRule
+        .onNodeWithTag(EditEventScreenTestTags.INPUT_EVENT_VISIBILITY)
+        .assertDoesNotExist()
+
+    // Verify editable fields are shown
+    composeTestRule.onNodeWithTag(EditEventScreenTestTags.INPUT_EVENT_TITLE).assertExists()
+    composeTestRule.onNodeWithTag(EditEventScreenTestTags.INPUT_EVENT_DESCRIPTION).assertExists()
+    composeTestRule.onNodeWithTag(EditEventScreenTestTags.INPUT_EVENT_LOCATION).assertExists()
+    composeTestRule.onNodeWithTag(EditEventScreenTestTags.INPUT_EVENT_DURATION).assertExists()
+    composeTestRule.onNodeWithTag(EditEventScreenTestTags.INPUT_EVENT_DATE).assertExists()
+    composeTestRule.onNodeWithTag(EditEventScreenTestTags.INPUT_EVENT_TIME).assertExists()
+  }
+
+  @Test
+  fun groupEvent_validationAndEditingBehavior() {
+    val repo = EventsRepositoryLocal()
+    val groupEvent = createTestGroupEvent()
+    runBlocking { repo.addEvent(groupEvent) }
+    val viewModel = EditEventViewModel(repo, MockLocationRepository())
+
+    viewModel.loadEvent(groupEvent.eventId)
+    composeTestRule.waitForIdle()
+    composeTestRule.mainClock.advanceTimeBy(2000)
+    composeTestRule.waitForIdle()
+
+    // Verify initial state is valid and is a group event
+    assert(viewModel.uiState.value.isGroupEvent)
+    assert(viewModel.uiState.value.isValid)
+
+    // Edit fields and verify groupId is preserved
+    viewModel.setTitle("New Title")
+    viewModel.setDescription("New Description")
+
+    assert(viewModel.uiState.value.groupId == "group-123")
+    assert(viewModel.uiState.value.isGroupEvent)
+    assert(viewModel.uiState.value.isValid)
+  }
+
+  @Test
+  fun groupEvent_canEditFieldsAndSaveButtonRemainsEnabled() {
+    val repo = EventsRepositoryLocal()
+    val groupEvent = createTestGroupEvent()
+    runBlocking { repo.addEvent(groupEvent) }
+    val viewModel = EditEventViewModel(repo, MockLocationRepository())
+
+    composeTestRule.setContent {
+      EditEventScreen(eventId = groupEvent.eventId, editEventViewModel = viewModel, onDone = {})
+    }
+
+    composeTestRule.waitForIdle()
+    composeTestRule.mainClock.advanceTimeBy(2000)
+    composeTestRule.waitForIdle()
+
+    // Edit title and description
+    composeTestRule.onNodeWithTag(EditEventScreenTestTags.INPUT_EVENT_TITLE).performTextClearance()
+    composeTestRule
+        .onNodeWithTag(EditEventScreenTestTags.INPUT_EVENT_TITLE)
+        .performTextInput("Updated Group Event Title")
+
+    composeTestRule
+        .onNodeWithTag(EditEventScreenTestTags.INPUT_EVENT_DESCRIPTION)
+        .performTextClearance()
+    composeTestRule
+        .onNodeWithTag(EditEventScreenTestTags.INPUT_EVENT_DESCRIPTION)
+        .performTextInput("Updated group description")
+
+    composeTestRule.waitForIdle()
+
+    // Save button should remain enabled
+    composeTestRule.waitUntil(timeoutMillis = 5_000) {
+      composeTestRule
+          .onAllNodesWithTag(EditEventScreenTestTags.EVENT_SAVE)
+          .fetchSemanticsNodes()
+          .firstOrNull()
+          ?.config
+          ?.getOrNull(SemanticsProperties.Disabled) == null
+    }
+
+    composeTestRule.onNodeWithTag(EditEventScreenTestTags.EVENT_SAVE).assertIsEnabled()
+  }
+
   /** --- ERROR MESSAGE DISPLAY TESTS --- */
   @Test
   fun invalidType_showsErrorMessage() {


### PR DESCRIPTION
## Description

This PR implements restricted editing for group events in the Edit Event screen. Group events now have limited editable fields (only title, description, location, duration, date, and time), while type, maxparticipants, and visibility remain locked to their group-level values.

## Changes

  EditEventViewModel.kt

  - Added groupId field to EditEventUIState to track if an event belongs to a group
  - Added isGroupEvent property that returns true when groupId is not null
  - Updated isValid validation logic:
    - Split validation into common fields (title, description, location, duration, date, time) and standalone-only fields (type, maxParticipants, visibility)
    - Group events only validate common fields since type/maxParticipants/visibility are not editable
    - Standalone events validate all fields as before
  - Updated editEvent() to preserve groupId when saving changes

  EditEventScreen.kt

  - Some textfields (group, type, maxParticipants, visibility) for group events are hidden

## Screenshots

<img width="200" height="500" alt="image" src="https://github.com/user-attachments/assets/abe305d5-a01d-4ff4-871c-a9e9d98590c7" />

## Issue

Closes #401

Note: This description was co-written with AI (Claude).