### PR TITLE
Profile load in test

### DIFF
--- a/app/src/androidTest/java/com/android/joinme/ui/navigation/MainActivityNavigationTest.kt
+++ b/app/src/androidTest/java/com/android/joinme/ui/navigation/MainActivityNavigationTest.kt
@@ -17,6 +17,7 @@ import com.android.joinme.model.serie.SeriesRepositoryLocal
 import com.android.joinme.model.serie.SeriesRepositoryProvider
 import com.android.joinme.model.utils.Visibility
 import com.android.joinme.ui.groups.GroupDetailScreenTestTags
+import com.android.joinme.ui.groups.GroupListScreenTestTags
 import com.android.joinme.ui.groups.GroupListScreenTestTags.cardTag
 import com.android.joinme.ui.overview.CreateEventForSerieScreenTestTags
 import com.android.joinme.ui.overview.CreateEventScreenTestTags
@@ -1509,41 +1510,92 @@ class MainActivityNavigationTest {
     composeTestRule.onNodeWithTag("eventItemtest-group-activity-1").assertExists()
   }
 
-    @Test
-    fun editProfileScreen_composable_navigateProfile() {
-        composeTestRule.waitForIdle()
-        composeTestRule.mainClock.advanceTimeBy(2000)
-        composeTestRule.waitForIdle()
+  @Test
+  fun editProfileScreen_composable_navigateProfile() {
+    composeTestRule.waitForIdle()
+    composeTestRule.mainClock.advanceTimeBy(2000)
+    composeTestRule.waitForIdle()
 
-        // Step 1: Navigate to Profile tab
-        composeTestRule.onNodeWithTag(NavigationTestTags.tabTag("Profile")).performClick()
-        composeTestRule.waitForIdle()
-        composeTestRule.mainClock.advanceTimeBy(1000)
-        composeTestRule.waitForIdle()
+    // Step 1: Navigate to Profile tab
+    composeTestRule.onNodeWithTag(NavigationTestTags.tabTag("Profile")).performClick()
+    composeTestRule.waitForIdle()
+    composeTestRule.mainClock.advanceTimeBy(1000)
+    composeTestRule.waitForIdle()
 
-        // Step 2: Click Groups button (content description)
-        composeTestRule.onNodeWithContentDescription("Edit").performClick()
-        composeTestRule.waitForIdle()
-        composeTestRule.mainClock.advanceTimeBy(1000)
-        composeTestRule.waitForIdle()
+    // Step 2: Click Groups button (content description)
+    composeTestRule.onNodeWithContentDescription("Edit").performClick()
+    composeTestRule.waitForIdle()
+    composeTestRule.mainClock.advanceTimeBy(1000)
+    composeTestRule.waitForIdle()
 
-        // Step 3: Modify profile name
-        composeTestRule.onNodeWithTag(EditProfileTestTags.USERNAME_FIELD).performClick()
-        composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithTag(EditProfileTestTags.USERNAME_FIELD).performTextClearance()
-        composeTestRule.onNodeWithTag(EditProfileTestTags.USERNAME_FIELD).performTextInput("Updated Test User")
-        composeTestRule.waitForIdle()
-        composeTestRule.mainClock.advanceTimeBy(1000)
-        composeTestRule.waitForIdle()
+    // Step 3: Modify profile name
+    composeTestRule.onNodeWithTag(EditProfileTestTags.USERNAME_FIELD).performClick()
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithTag(EditProfileTestTags.USERNAME_FIELD).performTextClearance()
+    composeTestRule
+        .onNodeWithTag(EditProfileTestTags.USERNAME_FIELD)
+        .performTextInput("Updated Test User")
+    composeTestRule.waitForIdle()
+    composeTestRule.mainClock.advanceTimeBy(1000)
+    composeTestRule.waitForIdle()
 
-        // Step 4: Click Save button
-        composeTestRule.onNodeWithTag(EditProfileTestTags.SAVE_BUTTON).performScrollTo()
-        composeTestRule.onNodeWithTag(EditProfileTestTags.SAVE_BUTTON).performClick()
-        composeTestRule.waitForIdle()
-        composeTestRule.mainClock.advanceTimeBy(1000)
+    // Step 4: Click Save button
+    composeTestRule.onNodeWithTag(EditProfileTestTags.SAVE_BUTTON).performScrollTo()
+    composeTestRule.onNodeWithTag(EditProfileTestTags.SAVE_BUTTON).performClick()
+    composeTestRule.waitForIdle()
+    composeTestRule.mainClock.advanceTimeBy(1000)
 
-        // Step 5: Verify profile name is updated
-        composeTestRule.onNodeWithTag(ViewProfileTestTags.USERNAME_FIELD).assertIsDisplayed()
-        composeTestRule.onNodeWithText("Updated Test User").assertExists()
-    }
+    // Step 5: Verify profile name is updated
+    composeTestRule.onNodeWithTag(ViewProfileTestTags.USERNAME_FIELD).assertIsDisplayed()
+    composeTestRule.onNodeWithText("Updated Test User").assertExists()
+
+    // Back to EditProfile screen
+    composeTestRule.onNodeWithContentDescription("Edit").performClick()
+    composeTestRule.waitForIdle()
+    composeTestRule.mainClock.advanceTimeBy(1000)
+
+    // Back Navigation of Edit Profile Test
+    composeTestRule.onNodeWithContentDescription("Back").performClick()
+    composeTestRule.waitForIdle()
+    composeTestRule.mainClock.advanceTimeBy(1000)
+
+    // Verify we're back on Profile screen
+    composeTestRule.onNodeWithTag(ViewProfileTestTags.SCREEN).assertExists()
+
+    // Navigate back to EditProfile screen
+    composeTestRule.onNodeWithContentDescription("Edit").performClick()
+    composeTestRule.waitForIdle()
+    composeTestRule.mainClock.advanceTimeBy(1000)
+
+    // Test GroupNavigation from EditProfile Screen
+    composeTestRule.onNodeWithContentDescription("Group").performClick()
+    composeTestRule.waitForIdle()
+    composeTestRule.mainClock.advanceTimeBy(1000)
+
+    // Verify we're on Group Screen
+    composeTestRule.onNodeWithTag(GroupListScreenTestTags.LIST).assertExists()
+
+    // Navigate back to Profile Screen
+    composeTestRule.onNodeWithContentDescription("Profile").performClick()
+    composeTestRule.waitForIdle()
+    composeTestRule.mainClock.advanceTimeBy(1000)
+
+    // Verify we're back on Profile screen
+    composeTestRule.onNodeWithTag(ViewProfileTestTags.SCREEN).assertExists()
+
+    // Navigate back to EditProfile screen
+    composeTestRule.onNodeWithContentDescription("Edit").performClick()
+    composeTestRule.waitForIdle()
+    composeTestRule.mainClock.advanceTimeBy(1000)
+
+    // Verify we're on EditProfile screen
+    composeTestRule.onNodeWithTag(EditProfileTestTags.SCREEN).assertExists()
+
+    // Test to navigate to profile using EditProfile TopAppBar
+    composeTestRule.onNodeWithContentDescription("Profile").performClick()
+    composeTestRule.waitForIdle()
+
+    // Verify we're on Profile screen
+    composeTestRule.onNodeWithTag(ViewProfileTestTags.SCREEN).assertExists()
+  }
 }

--- a/app/src/main/java/com/android/joinme/MainActivity.kt
+++ b/app/src/main/java/com/android/joinme/MainActivity.kt
@@ -162,14 +162,15 @@ fun JoinMe(
   }
 
   // Get current user ID with test mode support
-  val currentUserId = remember(currentUser) {
-    val isTestEnv =
-        android.os.Build.FINGERPRINT == "robolectric" ||
-            android.os.Debug.isDebuggerConnected() ||
-            System.getProperty("IS_TEST_ENV") == "true"
+  val currentUserId =
+      remember(currentUser) {
+        val isTestEnv =
+            android.os.Build.FINGERPRINT == "robolectric" ||
+                android.os.Debug.isDebuggerConnected() ||
+                System.getProperty("IS_TEST_ENV") == "true"
 
-    if (isTestEnv) "test-user-id" else (currentUser?.uid ?: "")
-  }
+        if (isTestEnv) "test-user-id" else (currentUser?.uid ?: "")
+      }
 
   val initialDestination =
       startDestination ?: if (currentUser == null) Screen.Auth.name else Screen.Overview.route


### PR DESCRIPTION
Fix profile display in navigation tests by adding test-aware user ID handling in MainActivity and setting up
  profile test data in MainActivityNavigationTest.

  ## Problem

  Navigation tests were failing to display user profiles because:
  - Without Firebase Auth in tests, `currentUser?.uid` returns `null`, resulting in an empty string `""`
  - ProfileViewModel rejects blank UIDs with error: "User not authenticated. Please sign in again."
  - Tests  could not navigate through Profile screen

  ## Solution

  Implement the same test mode detection pattern  to provide a consistent test user ID across the app.


---

  ### Changes Made

  #### MainActivity.kt
  - Added `currentUserId` computed property that detects test environment via `IS_TEST_ENV` system property
  - Returns `"test-user-id"` in test mode, otherwise uses Firebase Auth UID
  - Updated `ViewProfileScreen` and `EditProfileScreen` to use `currentUserId` instead of `currentUser?.uid ?: ""`
  - Removed duplicate `currentUserId` declaration in ChatScreen composable

  #### MainActivityNavigationTest.kt
  - Created test profile with `uid = "test-user-id"` matching the test mode user ID
  - Profile now loads successfully when navigating to Profile tab in tests
  - Implement all the Navigation callback of EditProfile screen in `editProfileScreen_composable_navigateProfile`
  
  ## Related Issue
  - #386 
  
  ## Note
  This Pr description has been co-written with the help of AI


