### PR TITLE
feat(poll): Add poll repository with Firebase Realtime Database implementation

### DIFF
--- a/app/src/main/java/com/android/joinme/model/chat/PollRepository.kt
+++ b/app/src/main/java/com/android/joinme/model/chat/PollRepository.kt
@@ -1,5 +1,7 @@
 package com.android.joinme.model.chat
 
+// Implemented with help of Claude AI
+
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -77,9 +79,10 @@ interface PollRepository {
    *
    * @param conversationId The unique identifier of the conversation containing the poll.
    * @param pollId The unique identifier of the poll to close.
-   * @throws Exception if the poll is not found.
+   * @param userId The ID of the user attempting to close the poll.
+   * @throws Exception if the poll is not found or user is not the poll owner.
    */
-  suspend fun closePoll(conversationId: String, pollId: String)
+  suspend fun closePoll(conversationId: String, pollId: String, userId: String)
 
   /**
    * Reopens a closed poll, allowing voting again.
@@ -88,9 +91,10 @@ interface PollRepository {
    *
    * @param conversationId The unique identifier of the conversation containing the poll.
    * @param pollId The unique identifier of the poll to reopen.
-   * @throws Exception if the poll is not found.
+   * @param userId The ID of the user attempting to reopen the poll.
+   * @throws Exception if the poll is not found or user is not the poll owner.
    */
-  suspend fun reopenPoll(conversationId: String, pollId: String)
+  suspend fun reopenPoll(conversationId: String, pollId: String, userId: String)
 
   /**
    * Deletes a poll from a conversation.
@@ -99,7 +103,8 @@ interface PollRepository {
    *
    * @param conversationId The unique identifier of the conversation containing the poll.
    * @param pollId The unique identifier of the poll to delete.
-   * @throws Exception if the poll is not found.
+   * @param userId The ID of the user attempting to delete the poll.
+   * @throws Exception if the poll is not found or user is not the poll owner.
    */
-  suspend fun deletePoll(conversationId: String, pollId: String)
+  suspend fun deletePoll(conversationId: String, pollId: String, userId: String)
 }


### PR DESCRIPTION
<html><head></head><body><h2>Description</h2>
<h3>Summary</h3>
<p>This PR introduces the repository layer for the interactive polls feature, enabling poll data management with real-time synchronization using Firebase Realtime Database.</p>
<h3>Changes</h3>
<p><strong>New Files:</strong></p>
<ul>
<li><code>PollRepository.kt</code> - Interface defining the contract for poll operations</li>
<li><code>PollRepositoryRealtimeDatabase.kt</code> - Firebase Realtime Database implementation</li>
<li><code>PollRepositoryRealtimeDatabaseTest.kt</code> - Comprehensive unit tests</li>
</ul>
<p><strong>Interface Methods:</strong></p>

Method | Description
-- | --
getNewPollId() | Generates a unique poll ID
observePollsForConversation() | Returns a real-time Flow of polls for a conversation
getPoll() | Fetches a single poll by ID
createPoll() | Creates a new poll
vote() | Casts a vote (handles single vs multi-answer modes)
removeVote() | Removes a user's vote from an option
closePoll() | Closes a poll to prevent further voting
reopenPoll() | Reopens a closed poll
deletePoll() | Deletes a poll


<p><strong>Implementation Details:</strong></p>
<ul>
<li>Data structure: Polls stored at <code>conversations/{conversationId}/polls/{pollId}</code></li>
<li>Real-time sync: Uses <code>ValueEventListener</code> with <code>callbackFlow</code> for live updates</li>
<li>Vote logic: Single-answer polls auto-remove previous vote; multi-answer polls allow multiple selections</li>
<li>Helper methods for serialization/deserialization between Poll objects and Firebase data</li>
</ul>
<h3>Testing</h3>
<p>Added comprehensive unit tests covering:</p>
<ul>
<li>ID generation and null handling</li>
<li>Real-time observation with error handling and invalid poll filtering</li>
<li>Poll retrieval for existing and non-existent polls</li>
<li>Vote casting with closed poll and not-found error scenarios</li>
<li>Vote removal with proper validation</li>
<li>Poll lifecycle operations (close, reopen, delete)</li>
</ul>
<h3>Endgoal</h3>

https://github.com/user-attachments/assets/3ef3b26b-312f-4edb-8a9b-b4dd30671aac


https://github.com/user-attachments/assets/7a839878-ed85-49d4-a76a-5e1b48655121


https://github.com/user-attachments/assets/0bfbc37d-930f-44e5-8bcd-e0ac37d4e6b3


https://github.com/user-attachments/assets/37514d04-9fbd-4db7-84d3-12b1be17da2d

<hr>
<p><em>PS: This PR description was written with the help of Claude AI.</em></p></body></html>