### PR TITLE
fix(chat): replace mic button with send button

### DIFF
--- a/app/src/main/java/com/android/joinme/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/android/joinme/ui/chat/ChatScreen.kt
@@ -42,7 +42,6 @@ import androidx.compose.material.icons.filled.DoneAll
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.LocationOn
-import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -897,8 +896,6 @@ private fun MessageInput(
     isUploadingImage: Boolean
 ) {
   var showAttachmentMenu by remember { mutableStateOf(false) }
-  val context = LocalContext.current
-  val notImplementedMsg = stringResource(R.string.not_yet_implemented)
 
   Column {
     // Upload progress indicator
@@ -941,23 +938,20 @@ private fun MessageInput(
                 colors = MaterialTheme.customColors.outlinedTextField(),
                 maxLines = 4)
 
-            // Dynamic send/mic button (right)
+            // Dynamic send button (right) - disabled appearance when no text
             if (text.isEmpty()) {
-              // Microphone button (placeholder for future audio recording)
-              // TODO(#364 and #367): Audio recording - Feature coming soon
+              // Disabled send button appearance when no text
               IconButton(
-                  onClick = {
-                    Toast.makeText(context, notImplementedMsg, Toast.LENGTH_SHORT).show()
-                  },
-                  enabled = !isUploadingImage,
+                  onClick = {},
+                  enabled = false,
                   modifier =
                       Modifier.size(Dimens.TouchTarget.minimum)
                           .background(
                               color = MaterialTheme.colorScheme.surfaceVariant, shape = CircleShape)
-                          .testTag(ChatScreenTestTags.MIC_BUTTON)) {
+                          .testTag(ChatScreenTestTags.SEND_BUTTON)) {
                     Icon(
-                        imageVector = Icons.Default.Mic,
-                        contentDescription = stringResource(R.string.record_audio),
+                        imageVector = Icons.AutoMirrored.Filled.Send,
+                        contentDescription = stringResource(R.string.send_message),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant)
                   }
             } else {

--- a/app/src/test/java/com/android/joinme/ui/chat/ChatScreenTest.kt
+++ b/app/src/test/java/com/android/joinme/ui/chat/ChatScreenTest.kt
@@ -108,8 +108,8 @@ class ChatScreenTest {
     composeTestRule.onNodeWithTag(ChatScreenTestTags.MESSAGE_LIST).assertExists()
     composeTestRule.onNodeWithTag(ChatScreenTestTags.MESSAGE_INPUT).assertIsDisplayed()
     composeTestRule.onNodeWithTag(ChatScreenTestTags.ATTACHMENT_BUTTON).assertIsDisplayed()
-    // Mic button is shown when text field is empty (send button appears when typing)
-    composeTestRule.onNodeWithTag(ChatScreenTestTags.MIC_BUTTON).assertIsDisplayed()
+    // Send button is always shown (disabled when text field is empty)
+    composeTestRule.onNodeWithTag(ChatScreenTestTags.SEND_BUTTON).assertIsDisplayed()
   }
 
   // ============================================================================
@@ -199,14 +199,13 @@ class ChatScreenTest {
   // ============================================================================
 
   @Test
-  fun messageInput_sendButtonAppearsAndIsEnabled_whenTextEntered() {
+  fun messageInput_sendButtonIsEnabledWhenTextEntered() {
     setupChatScreen()
 
-    // Initially mic button is shown, not send button
-    composeTestRule.onNodeWithTag(ChatScreenTestTags.MIC_BUTTON).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ChatScreenTestTags.SEND_BUTTON).assertDoesNotExist()
+    // Initially send button is shown but disabled
+    composeTestRule.onNodeWithTag(ChatScreenTestTags.SEND_BUTTON).assertIsDisplayed()
 
-    // When input has text, send button appears and is enabled
+    // When input has text, send button becomes enabled
     composeTestRule.onNodeWithTag(ChatScreenTestTags.MESSAGE_INPUT).performTextInput("Hello!")
     composeTestRule.waitForIdle()
     composeTestRule.onNodeWithTag(ChatScreenTestTags.SEND_BUTTON).assertIsDisplayed()
@@ -288,28 +287,26 @@ class ChatScreenTest {
   }
 
   // ============================================================================
-  // Mic/Send Button Toggle Tests
+  // Send Button State Tests
   // ============================================================================
 
   @Test
-  fun buttonToggle_switchesBetweenMicAndSend_basedOnTextInput() {
+  fun sendButton_togglesEnabledState_basedOnTextInput() {
     setupChatScreen()
 
-    // Initially mic button is shown when text is empty
-    composeTestRule.onNodeWithTag(ChatScreenTestTags.MIC_BUTTON).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ChatScreenTestTags.SEND_BUTTON).assertDoesNotExist()
+    // Initially send button is shown but disabled when text is empty
+    composeTestRule.onNodeWithTag(ChatScreenTestTags.SEND_BUTTON).assertIsDisplayed()
 
-    // Type some text - should switch to send button
+    // Type some text - send button should become enabled
     composeTestRule.onNodeWithTag(ChatScreenTestTags.MESSAGE_INPUT).performTextInput("Hello")
     composeTestRule.waitForIdle()
     composeTestRule.onNodeWithTag(ChatScreenTestTags.SEND_BUTTON).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ChatScreenTestTags.MIC_BUTTON).assertDoesNotExist()
+    composeTestRule.onNodeWithTag(ChatScreenTestTags.SEND_BUTTON).assertIsEnabled()
 
-    // Clear the text - should switch back to mic button
+    // Clear the text - send button should become disabled again
     composeTestRule.onNodeWithTag(ChatScreenTestTags.MESSAGE_INPUT).performTextClearance()
     composeTestRule.waitForIdle()
-    composeTestRule.onNodeWithTag(ChatScreenTestTags.MIC_BUTTON).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ChatScreenTestTags.SEND_BUTTON).assertDoesNotExist()
+    composeTestRule.onNodeWithTag(ChatScreenTestTags.SEND_BUTTON).assertIsDisplayed()
   }
 
   // ============================================================================
@@ -378,23 +375,23 @@ class ChatScreenTest {
   }
 
   @Test
-  fun sendMessage_clearsInputAndShowsMicButton() {
+  fun sendMessage_clearsInputAndDisablesSendButton() {
     setupChatScreen()
 
     // Type a message
     composeTestRule.onNodeWithTag(ChatScreenTestTags.MESSAGE_INPUT).performTextInput("Test message")
     composeTestRule.waitForIdle()
 
-    // Verify send button is shown
+    // Verify send button is shown and enabled
     composeTestRule.onNodeWithTag(ChatScreenTestTags.SEND_BUTTON).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(ChatScreenTestTags.SEND_BUTTON).assertIsEnabled()
 
     // Send the message
     composeTestRule.onNodeWithTag(ChatScreenTestTags.SEND_BUTTON).performClick()
     composeTestRule.waitForIdle()
 
-    // Input should be cleared and mic button should reappear
-    composeTestRule.onNodeWithTag(ChatScreenTestTags.MIC_BUTTON).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ChatScreenTestTags.SEND_BUTTON).assertDoesNotExist()
+    // Input should be cleared and send button should still be visible (but disabled)
+    composeTestRule.onNodeWithTag(ChatScreenTestTags.SEND_BUTTON).assertIsDisplayed()
   }
 
   // ============================================================================


### PR DESCRIPTION
**Description:**

## Summary

Replaces the microphone button with a send button that is always visible, removing the color indication when the message field is empty.

## Changes

### ChatScreen.kt
- Remove mic button from message input area
- Display send button permanently regardless of message state
- Remove visual color change when message is empty (button appears the same whether enabled or disabled)

### ChatScreenTest.kt
- `chatScreen_displaysAllUIElements`: Check for SEND_BUTTON instead of MIC_BUTTON
- `messageInput_sendButtonAppearsAndIsEnabled_whenTextEntered` → `messageInput_sendButtonIsEnabledWhenTextEntered`: Remove expectation that mic button is initially shown; verify send button becomes enabled when text is entered
- `buttonToggle_switchesBetweenMicAndSend_basedOnTextInput` → `sendButton_togglesEnabledState_basedOnTextInput`: Test send button enabled state instead of mic/send toggle
- `sendMessage_clearsInputAndShowsMicButton` → `sendMessage_clearsInputAndDisablesSendButton`: Verify send button remains visible (disabled) after sending instead of mic button reappearing

## UI Preview

<img width="347" height="731" alt="Screenshot 2025-12-04 at 5 05 59 PM" src="https://github.com/user-attachments/assets/59fa7a51-1b41-4435-b630-a2b36462fb5a" />
<img width="346" height="732" alt="Screenshot 2025-12-04 at 5 06 21 PM" src="https://github.com/user-attachments/assets/80a217c5-0b99-433f-814f-9e4d7bd7bc2e" />

## AI Assistance

_This PR description was written with help of Claude AI._