### PR TITLE
fix(calendar): add launch effect to recompose screen

### DIFF
--- a/app/src/main/java/com/android/joinme/ui/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/android/joinme/ui/calendar/CalendarScreen.kt
@@ -67,6 +67,9 @@ fun CalendarScreen(
   val context = LocalContext.current
   val uiState by calendarViewModel.uiState.collectAsState()
 
+  // Refresh calendar data when screen is recomposed
+  LaunchedEffect(Unit) { calendarViewModel.refreshItems() }
+
   LaunchedEffect(uiState.error) {
     uiState.error?.let { message ->
       Toast.makeText(context, message, Toast.LENGTH_SHORT).show()


### PR DESCRIPTION
## Description

When deleting an event or a serie from CalendarScreen, the event card wouldn't disappear. To adjust the fix, we just refresh the calendar data each time the screen is recomposed.

## Issue
Closes #467 