### PR TITLE
fix(group): fix group activity screen and viewmodel

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -192,4 +192,8 @@
     <!-- Group message -->
     <string name="currently_not">You are currently not</string>
     <string name="assigned_to_group">assigned to a group…</string>
+
+    <!-- Activity Group Screen -->
+    <string name="group_activities_title">%1$s Activities</string>
+    <string name="group_activities_default">Group Activities</string>
 </resources>

--- a/app/src/test/java/com/android/joinme/ui/groups/ActivityGroupScreenTest.kt
+++ b/app/src/test/java/com/android/joinme/ui/groups/ActivityGroupScreenTest.kt
@@ -101,7 +101,7 @@ class ActivityGroupScreenTest {
   }
 
   @Test
-  fun activityGroupScreen_displaysTopBarAndBackButton() {
+  fun activityGroupScreen_displaysGroupNameInTitle() {
     val viewModel = createViewModel()
 
     runBlocking { groupRepo.addGroup(Group(id = "1", name = "Test Group")) }
@@ -112,10 +112,22 @@ class ActivityGroupScreenTest {
 
     waitForContent()
 
-    // Group assertions that use the same setup
+    composeTestRule.onNodeWithText("Test Group Activities").assertIsDisplayed()
+  }
+
+  @Test
+  fun activityGroupScreen_displaysFallbackTitleWhenGroupNameEmpty() {
+    val viewModel = createViewModel()
+
+    runBlocking { groupRepo.addGroup(Group(id = "1", name = "")) }
+
+    composeTestRule.setContent {
+      ActivityGroupScreen(groupId = "1", activityGroupViewModel = viewModel)
+    }
+
+    waitForContent()
+
     composeTestRule.onNodeWithText("Group Activities").assertIsDisplayed()
-    composeTestRule.onNodeWithTag(ActivityGroupScreenTestTags.BACK_BUTTON).assertIsDisplayed()
-    composeTestRule.onNodeWithContentDescription("Back").assertIsDisplayed()
   }
 
   @Test

--- a/app/src/test/java/com/android/joinme/ui/groups/ActivityGroupViewModelTest.kt
+++ b/app/src/test/java/com/android/joinme/ui/groups/ActivityGroupViewModelTest.kt
@@ -6,13 +6,17 @@ import com.android.joinme.model.event.Event
 import com.android.joinme.model.event.EventType
 import com.android.joinme.model.event.EventVisibility
 import com.android.joinme.model.event.EventsRepository
+import com.android.joinme.model.eventItem.EventItem
 import com.android.joinme.model.groups.Group
 import com.android.joinme.model.groups.GroupRepository
+import com.android.joinme.model.serie.Serie
 import com.android.joinme.model.serie.SeriesRepository
+import com.android.joinme.model.utils.Visibility
 import com.google.firebase.Timestamp
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import java.util.Calendar
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -40,8 +44,23 @@ class ActivityGroupViewModelTest {
 
   // Test data
   private val testGroupId = "group123"
+  private val testGroupName = "Test Group"
   private val testEventId1 = "event1"
   private val testEventId2 = "event2"
+  private val testEventId3 = "event3"
+  private val testSerieId1 = "serie1"
+
+  private fun createFutureTimestamp(daysFromNow: Int = 1): Timestamp {
+    val calendar = Calendar.getInstance()
+    calendar.add(Calendar.DAY_OF_YEAR, daysFromNow)
+    return Timestamp(calendar.time)
+  }
+
+  private fun createPastTimestamp(daysAgo: Int = 1): Timestamp {
+    val calendar = Calendar.getInstance()
+    calendar.add(Calendar.DAY_OF_YEAR, -daysAgo)
+    return Timestamp(calendar.time)
+  }
 
   private val testEvent1 =
       Event(
@@ -50,7 +69,7 @@ class ActivityGroupViewModelTest {
           title = "Football Match",
           description = "Weekly football game",
           location = null,
-          date = Timestamp.now(),
+          date = createFutureTimestamp(1),
           duration = 90,
           participants = listOf("user1", "user2"),
           maxParticipants = 20,
@@ -65,13 +84,68 @@ class ActivityGroupViewModelTest {
           title = "Bowling Night",
           description = "Fun bowling session",
           location = null,
-          date = Timestamp.now(),
+          date = createFutureTimestamp(2),
           duration = 120,
           participants = listOf("user1", "user3"),
           maxParticipants = 10,
           visibility = EventVisibility.PUBLIC,
           ownerId = "owner1",
           partOfASerie = false)
+
+  private val testEventInSerie =
+      Event(
+          eventId = testEventId3,
+          type = EventType.SPORTS,
+          title = "Serie Event",
+          description = "Event part of serie",
+          location = null,
+          date = createFutureTimestamp(3),
+          duration = 60,
+          participants = listOf("user1"),
+          maxParticipants = 15,
+          visibility = EventVisibility.PUBLIC,
+          ownerId = "owner1",
+          partOfASerie = true)
+
+  private val testExpiredEvent =
+      Event(
+          eventId = "expiredEvent",
+          type = EventType.SOCIAL,
+          title = "Old Event",
+          description = "Already happened",
+          location = null,
+          date = createPastTimestamp(2),
+          duration = 60,
+          participants = listOf("user1"),
+          maxParticipants = 10,
+          visibility = EventVisibility.PUBLIC,
+          ownerId = "owner1",
+          partOfASerie = false)
+
+  private val testSerie =
+      Serie(
+          serieId = testSerieId1,
+          title = "Weekly Football",
+          description = "Weekly football series",
+          date = createFutureTimestamp(1),
+          participants = listOf("user1", "user2"),
+          maxParticipants = 20,
+          visibility = Visibility.PUBLIC,
+          eventIds = listOf(testEventId3),
+          ownerId = "owner1")
+
+  private val testExpiredSerie =
+      Serie(
+          serieId = "expiredSerie",
+          title = "Old Serie",
+          description = "Expired serie",
+          date = createPastTimestamp(5),
+          participants = listOf("user1"),
+          maxParticipants = 10,
+          visibility = Visibility.PUBLIC,
+          eventIds = listOf(),
+          ownerId = "owner1",
+          lastEventEndTime = createPastTimestamp(3))
 
   @Before
   fun setup() {
@@ -95,41 +169,167 @@ class ActivityGroupViewModelTest {
   fun `initial state is correct`() {
     val state = viewModel.uiState.value
     assertFalse(state.isLoading)
-    assertTrue(state.events.isEmpty())
-    assertTrue(state.series.isEmpty())
+    assertEquals("", state.groupName)
+    assertTrue(state.items.isEmpty())
     assertNull(state.error)
   }
 
   @Test
-  fun `load successfully loads events and updates state`() = runTest {
+  fun `load successfully loads standalone events as EventItems`() = runTest {
     // Given
-    val group = Group(id = testGroupId, eventIds = listOf(testEventId1, testEventId2))
+    val group =
+        Group(
+            id = testGroupId,
+            name = testGroupName,
+            eventIds = listOf(testEventId1, testEventId2),
+            serieIds = emptyList())
     coEvery { groupRepository.getGroup(testGroupId) } returns group
     coEvery { eventsRepository.getEventsByIds(listOf(testEventId1, testEventId2)) } returns
         listOf(testEvent1, testEvent2)
+    coEvery { seriesRepository.getSeriesByIds(emptyList()) } returns emptyList()
 
     // When
     viewModel.load(testGroupId)
     advanceUntilIdle()
 
-    // Then - verify final state
-    val finalState = viewModel.uiState.value
-    assertFalse(finalState.isLoading)
-    assertEquals(2, finalState.events.size)
-    assertEquals(testEvent1, finalState.events[0])
-    assertEquals(testEvent2, finalState.events[1])
-    assertTrue(finalState.series.isEmpty())
-    assertNull(finalState.error)
-
-    // Verify repository interactions
-    coVerify(exactly = 1) { groupRepository.getGroup(testGroupId) }
-    coVerify(exactly = 1) { eventsRepository.getEventsByIds(listOf(testEventId1, testEventId2)) }
+    // Then
+    val state = viewModel.uiState.value
+    assertFalse(state.isLoading)
+    assertEquals(testGroupName, state.groupName)
+    assertEquals(2, state.items.size)
+    assertTrue(state.items[0] is EventItem.SingleEvent)
+    assertTrue(state.items[1] is EventItem.SingleEvent)
+    assertEquals(testEvent1, (state.items[0] as EventItem.SingleEvent).event)
+    assertEquals(testEvent2, (state.items[1] as EventItem.SingleEvent).event)
+    assertNull(state.error)
   }
 
   @Test
-  fun `load with empty event list returns empty events`() = runTest {
+  fun `load successfully loads series as EventItems`() = runTest {
     // Given
-    val group = Group(id = testGroupId, eventIds = emptyList())
+    val group =
+        Group(
+            id = testGroupId,
+            name = testGroupName,
+            eventIds = emptyList(),
+            serieIds = listOf(testSerieId1))
+    coEvery { groupRepository.getGroup(testGroupId) } returns group
+    coEvery { seriesRepository.getSeriesByIds(listOf(testSerieId1)) } returns listOf(testSerie)
+
+    // When
+    viewModel.load(testGroupId)
+    advanceUntilIdle()
+
+    // Then
+    val state = viewModel.uiState.value
+    assertFalse(state.isLoading)
+    assertEquals(1, state.items.size)
+    assertTrue(state.items[0] is EventItem.EventSerie)
+    assertEquals(testSerie, (state.items[0] as EventItem.EventSerie).serie)
+    assertNull(state.error)
+  }
+
+  @Test
+  fun `load filters out events that belong to series`() = runTest {
+    // Given - event3 belongs to serie1
+    val group =
+        Group(
+            id = testGroupId,
+            name = testGroupName,
+            eventIds = listOf(testEventId1, testEventId3),
+            serieIds = listOf(testSerieId1))
+    coEvery { groupRepository.getGroup(testGroupId) } returns group
+    coEvery { eventsRepository.getEventsByIds(listOf(testEventId1, testEventId3)) } returns
+        listOf(testEvent1, testEventInSerie)
+    coEvery { seriesRepository.getSeriesByIds(listOf(testSerieId1)) } returns listOf(testSerie)
+
+    // When
+    viewModel.load(testGroupId)
+    advanceUntilIdle()
+
+    // Then - only standalone event and serie should be in items
+    val state = viewModel.uiState.value
+    assertEquals(2, state.items.size)
+    assertTrue(state.items[0] is EventItem.SingleEvent)
+    assertTrue(state.items[1] is EventItem.EventSerie)
+    assertEquals(testEvent1, (state.items[0] as EventItem.SingleEvent).event)
+    assertEquals(testSerie, (state.items[1] as EventItem.EventSerie).serie)
+  }
+
+  @Test
+  fun `load filters out expired events`() = runTest {
+    // Given - mix of expired and non-expired events
+    val group =
+        Group(
+            id = testGroupId,
+            name = testGroupName,
+            eventIds = listOf(testEventId1, "expiredEvent"),
+            serieIds = emptyList())
+    coEvery { groupRepository.getGroup(testGroupId) } returns group
+    coEvery { eventsRepository.getEventsByIds(listOf(testEventId1, "expiredEvent")) } returns
+        listOf(testEvent1, testExpiredEvent)
+
+    // When
+    viewModel.load(testGroupId)
+    advanceUntilIdle()
+
+    // Then - only non-expired event should be in items
+    val state = viewModel.uiState.value
+    assertEquals(1, state.items.size)
+    assertEquals(testEvent1, (state.items[0] as EventItem.SingleEvent).event)
+  }
+
+  @Test
+  fun `load filters out expired series`() = runTest {
+    // Given - mix of expired and non-expired series
+    val group =
+        Group(
+            id = testGroupId,
+            name = testGroupName,
+            eventIds = emptyList(),
+            serieIds = listOf(testSerieId1, "expiredSerie"))
+    coEvery { groupRepository.getGroup(testGroupId) } returns group
+    coEvery { seriesRepository.getSeriesByIds(listOf(testSerieId1, "expiredSerie")) } returns
+        listOf(testSerie, testExpiredSerie)
+
+    // When
+    viewModel.load(testGroupId)
+    advanceUntilIdle()
+
+    // Then - only non-expired serie should be in items
+    val state = viewModel.uiState.value
+    assertEquals(1, state.items.size)
+    assertEquals(testSerie, (state.items[0] as EventItem.EventSerie).serie)
+  }
+
+  @Test
+  fun `load sorts items by date`() = runTest {
+    // Given - events with different dates (event1 is 1 day from now, event2 is 2 days)
+    val group =
+        Group(
+            id = testGroupId,
+            name = testGroupName,
+            eventIds = listOf(testEventId2, testEventId1),
+            serieIds = emptyList())
+    coEvery { groupRepository.getGroup(testGroupId) } returns group
+    coEvery { eventsRepository.getEventsByIds(listOf(testEventId2, testEventId1)) } returns
+        listOf(testEvent2, testEvent1)
+
+    // When
+    viewModel.load(testGroupId)
+    advanceUntilIdle()
+
+    // Then - items should be sorted by date (event1 before event2)
+    val state = viewModel.uiState.value
+    assertEquals(2, state.items.size)
+    assertEquals(testEvent1, (state.items[0] as EventItem.SingleEvent).event)
+    assertEquals(testEvent2, (state.items[1] as EventItem.SingleEvent).event)
+  }
+
+  @Test
+  fun `load with empty lists returns empty items`() = runTest {
+    // Given
+    val group = Group(id = testGroupId, name = testGroupName)
     coEvery { groupRepository.getGroup(testGroupId) } returns group
 
     // When
@@ -139,12 +339,11 @@ class ActivityGroupViewModelTest {
     // Then
     val state = viewModel.uiState.value
     assertFalse(state.isLoading)
-    assertTrue(state.events.isEmpty())
-    assertTrue(state.series.isEmpty())
+    assertEquals(testGroupName, state.groupName)
+    assertTrue(state.items.isEmpty())
     assertNull(state.error)
-
-    // Verify getEventsByIds was NOT called
     coVerify(exactly = 0) { eventsRepository.getEventsByIds(any()) }
+    coVerify(exactly = 0) { seriesRepository.getSeriesByIds(any()) }
   }
 
   @Test
@@ -160,15 +359,15 @@ class ActivityGroupViewModelTest {
     // Then
     val state = viewModel.uiState.value
     assertFalse(state.isLoading)
-    assertTrue(state.events.isEmpty())
-    assertTrue(state.series.isEmpty())
+    assertEquals("", state.groupName)
+    assertTrue(state.items.isEmpty())
     assertEquals("Failed to load group activities: $errorMessage", state.error)
   }
 
   @Test
   fun `load handles events repository error gracefully`() = runTest {
     // Given
-    val group = Group(id = testGroupId, eventIds = listOf(testEventId1))
+    val group = Group(id = testGroupId, name = testGroupName, eventIds = listOf(testEventId1))
     val errorMessage = "Network error"
     coEvery { groupRepository.getGroup(testGroupId) } returns group
     coEvery { eventsRepository.getEventsByIds(any()) } throws Exception(errorMessage)
@@ -180,71 +379,7 @@ class ActivityGroupViewModelTest {
     // Then
     val state = viewModel.uiState.value
     assertFalse(state.isLoading)
-    assertTrue(state.events.isEmpty())
-    assertTrue(state.series.isEmpty())
+    assertTrue(state.items.isEmpty())
     assertEquals("Failed to load group activities: $errorMessage", state.error)
-  }
-
-  @Test
-  fun `load with single event works correctly`() = runTest {
-    // Given
-    val group = Group(id = testGroupId, eventIds = listOf(testEventId1))
-    coEvery { groupRepository.getGroup(testGroupId) } returns group
-    coEvery { eventsRepository.getEventsByIds(listOf(testEventId1)) } returns listOf(testEvent1)
-
-    // When
-    viewModel.load(testGroupId)
-    advanceUntilIdle()
-
-    // Then
-    val state = viewModel.uiState.value
-    assertFalse(state.isLoading)
-    assertEquals(1, state.events.size)
-    assertEquals(testEvent1, state.events[0])
-    assertNull(state.error)
-  }
-
-  @Test
-  fun `multiple load calls update state correctly`() = runTest {
-    // Given - first group with events
-    val group1 = Group(id = "group1", eventIds = listOf(testEventId1))
-    coEvery { groupRepository.getGroup("group1") } returns group1
-    coEvery { eventsRepository.getEventsByIds(listOf(testEventId1)) } returns listOf(testEvent1)
-
-    // Given - second group with different events
-    val group2 = Group(id = "group2", eventIds = listOf(testEventId2))
-    coEvery { groupRepository.getGroup("group2") } returns group2
-    coEvery { eventsRepository.getEventsByIds(listOf(testEventId2)) } returns listOf(testEvent2)
-
-    // When - load first group
-    viewModel.load("group1")
-    advanceUntilIdle()
-
-    // Then - verify first load
-    assertEquals(1, viewModel.uiState.value.events.size)
-    assertEquals(testEvent1, viewModel.uiState.value.events[0])
-
-    // When - load second group
-    viewModel.load("group2")
-    advanceUntilIdle()
-
-    // Then - verify second load replaced first
-    assertEquals(1, viewModel.uiState.value.events.size)
-    assertEquals(testEvent2, viewModel.uiState.value.events[0])
-  }
-
-  @Test
-  fun `load preserves series as empty list for future implementation`() = runTest {
-    // Given
-    val group = Group(id = testGroupId, eventIds = listOf(testEventId1))
-    coEvery { groupRepository.getGroup(testGroupId) } returns group
-    coEvery { eventsRepository.getEventsByIds(any()) } returns listOf(testEvent1)
-
-    // When
-    viewModel.load(testGroupId)
-    advanceUntilIdle()
-
-    // Then - series should always be empty (reserved for future)
-    assertTrue(viewModel.uiState.value.series.isEmpty())
   }
 }


### PR DESCRIPTION
## Description

This PR improves the ActivityGroup feature by filtering out expired activities and providing a unified, chronological view of both events and series. Additionally, the screen title now displays the actual group name for better context.

## Changes

  ActivityGroupViewModel:
  - Added filtering to exclude expired events and series using isExpired() functions
  - Refactored with EventItem sealed class to unify events and series in a single list
  - Added groupName to UI state for display in screen title

  ActivityGroupScreen:
  - Updated to display mixed events and series using pattern matching (EventItem.SingleEvent / EventItem.EventSerie)
  - Modified title to show "{GroupName} Activities" instead of generic "Group Activities"

## Screenshots

<img width="200" height="500" alt="image" src="https://github.com/user-attachments/assets/0f13d574-61e6-430e-a0b7-be9694ece37f" />

Note that both M3 Deliverable are differeent events created by 2 different users.

## Issues

Closes #354 
Closes #492
Closes #496