### PR TITLE
Feature(chat) : add conversation cleanup when deleting entities

### DIFF
--- a/app/src/androidTest/java/com/android/joinme/ui/chat/ChatScreenAndroidTest.kt
+++ b/app/src/androidTest/java/com/android/joinme/ui/chat/ChatScreenAndroidTest.kt
@@ -124,6 +124,17 @@ class ChatScreenAndroidTest {
       }
       return uploadUrl
     }
+
+    override suspend fun deleteConversation(
+        conversationId: String,
+        pollRepository: com.android.joinme.model.chat.PollRepository?
+    ) {
+      // No-op for testing
+    }
+
+    override suspend fun deleteAllUserConversations(userId: String) {
+      // No-op for testing
+    }
   }
 
   private class FakeProfileRepository : ProfileRepository {

--- a/app/src/main/java/com/android/joinme/model/chat/ChatRepository.kt
+++ b/app/src/main/java/com/android/joinme/model/chat/ChatRepository.kt
@@ -87,4 +87,41 @@ interface ChatRepository {
       messageId: String,
       imageUri: Uri
   ): String
+
+  /**
+   * Deletes an entire conversation and all its associated data.
+   *
+   * This method performs a complete cleanup of a conversation including:
+   * - All messages in the conversation
+   * - All polls in the conversation (if PollRepository is provided)
+   * - All images stored in Firebase Storage for this conversation
+   * - The conversation node itself
+   *
+   * This operation is irreversible and should be called when entities (events, groups, series) that
+   * own conversations are deleted.
+   *
+   * @param conversationId The unique identifier of the conversation to delete.
+   * @param pollRepository Optional PollRepository instance to also delete polls. If null, only
+   *   messages and images will be deleted.
+   * @throws Exception if the deletion fails at any step.
+   */
+  suspend fun deleteConversation(conversationId: String, pollRepository: PollRepository? = null)
+
+  /**
+   * Deletes all direct message conversations involving a specific user.
+   *
+   * This method finds and deletes all conversations where the user is a participant in a direct
+   * message. Direct message conversation IDs follow the pattern "dm_{userId1}_{userId2}" where
+   * userIds are sorted alphabetically.
+   *
+   * This should be called when a user profile is deleted to clean up all their private
+   * conversations.
+   *
+   * Note: This method only works with Firebase Realtime Database implementation as it requires
+   * querying conversation nodes. The local implementation is a no-op.
+   *
+   * @param userId The unique identifier of the user whose conversations should be deleted.
+   * @throws Exception if the deletion fails.
+   */
+  suspend fun deleteAllUserConversations(userId: String)
 }

--- a/app/src/main/java/com/android/joinme/model/event/EventsRepositoryProvider.kt
+++ b/app/src/main/java/com/android/joinme/model/event/EventsRepositoryProvider.kt
@@ -1,6 +1,7 @@
 package com.android.joinme.model.event
 
 import android.content.Context
+import com.android.joinme.model.chat.ChatRepositoryProvider
 import com.android.joinme.network.NetworkMonitor
 import com.google.firebase.FirebaseApp
 import com.google.firebase.firestore.ktx.firestore
@@ -65,7 +66,10 @@ object EventsRepositoryProvider {
       if (apps.isEmpty()) {
         FirebaseApp.initializeApp(context)
       }
-      firestoreRepo = EventsRepositoryFirestore(Firebase.firestore, context)
+      val chatRepository = ChatRepositoryProvider.repository
+      firestoreRepo =
+          EventsRepositoryFirestore(
+              db = Firebase.firestore, context = context, chatRepository = chatRepository)
     }
     return firestoreRepo!!
   }

--- a/app/src/main/java/com/android/joinme/model/groups/GroupRepositoryProvider.kt
+++ b/app/src/main/java/com/android/joinme/model/groups/GroupRepositoryProvider.kt
@@ -1,5 +1,6 @@
 package com.android.joinme.model.groups
 
+import com.android.joinme.model.chat.ChatRepositoryProvider
 import com.google.firebase.Firebase
 import com.google.firebase.firestore.firestore
 import com.google.firebase.storage.storage
@@ -16,7 +17,9 @@ object GroupRepositoryProvider {
 
   // Firestore-backed repository
   private val firestoreRepo: GroupRepository by lazy {
-    GroupRepositoryFirestore(Firebase.firestore, Firebase.storage)
+    val chatRepository = ChatRepositoryProvider.repository
+    GroupRepositoryFirestore(
+        db = Firebase.firestore, storage = Firebase.storage, chatRepository = chatRepository)
   }
 
   // For backward compatibility and explicit test injection

--- a/app/src/main/java/com/android/joinme/model/profile/ProfileRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/joinme/model/profile/ProfileRepositoryFirestore.kt
@@ -3,6 +3,7 @@ package com.android.joinme.model.profile
 import android.content.Context
 import android.net.Uri
 import android.util.Log
+import com.android.joinme.model.chat.ChatRepository
 import com.android.joinme.model.utils.ImageProcessor
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.DocumentSnapshot
@@ -50,7 +51,8 @@ private const val F_FOLLOWED_ID = "followedId"
  */
 class ProfileRepositoryFirestore(
     private val db: FirebaseFirestore,
-    private val storage: FirebaseStorage
+    private val storage: FirebaseStorage,
+    private val chatRepository: ChatRepository? = null
 ) : ProfileRepository {
 
   private val profilesCollection = db.collection(PROFILES_COLLECTION_PATH)
@@ -126,7 +128,11 @@ class ProfileRepositoryFirestore(
   }
 
   override suspend fun deleteProfile(uid: String) {
+    // Delete the profile from Firestore
     profilesCollection.document(uid).delete().await()
+
+    // Delete all direct message conversations involving this user
+    chatRepository?.deleteAllUserConversations(uid)
   }
 
   /**

--- a/app/src/main/java/com/android/joinme/model/profile/ProfileRepositoryProvider.kt
+++ b/app/src/main/java/com/android/joinme/model/profile/ProfileRepositoryProvider.kt
@@ -1,5 +1,6 @@
 package com.android.joinme.model.profile
 
+import com.android.joinme.model.chat.ChatRepositoryProvider
 import com.google.firebase.Firebase
 import com.google.firebase.firestore.firestore
 import com.google.firebase.storage.FirebaseStorage
@@ -13,7 +14,11 @@ object ProfileRepositoryProvider {
   private val localRepo: ProfileRepository by lazy { ProfileRepositoryLocal() }
 
   private val firestoreRepo: ProfileRepository by lazy {
-    ProfileRepositoryFirestore(db = Firebase.firestore, storage = FirebaseStorage.getInstance())
+    val chatRepository = ChatRepositoryProvider.repository
+    ProfileRepositoryFirestore(
+        db = Firebase.firestore,
+        storage = FirebaseStorage.getInstance(),
+        chatRepository = chatRepository)
   }
 
   // For backward compatibility and explicit test injection

--- a/app/src/main/java/com/android/joinme/model/serie/SeriesRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/joinme/model/serie/SeriesRepositoryFirestore.kt
@@ -1,5 +1,6 @@
 package com.android.joinme.model.serie
 
+import com.android.joinme.model.chat.ChatRepository
 import com.android.joinme.model.event.EVENTS_COLLECTION_PATH
 import com.android.joinme.model.event.isActive
 import com.android.joinme.model.event.isExpired
@@ -61,7 +62,10 @@ enum class SerieFilter {
  *
  * @property db The FirebaseFirestore instance used for database operations
  */
-class SeriesRepositoryFirestore(private val db: FirebaseFirestore) : SeriesRepository {
+class SeriesRepositoryFirestore(
+    private val db: FirebaseFirestore,
+    private val chatRepository: ChatRepository? = null
+) : SeriesRepository {
   /**
    * Generates and returns a new unique identifier for a Serie item.
    *
@@ -150,8 +154,11 @@ class SeriesRepositoryFirestore(private val db: FirebaseFirestore) : SeriesRepos
     serie.eventIds.forEach { eventId ->
       db.collection(EVENTS_COLLECTION_PATH).document(eventId).delete().await()
     }
-    // Delete serie
+    // Delete the serie from Firestore
     db.collection(SERIES_COLLECTION_PATH).document(serieId).delete().await()
+
+    // Delete the associated conversation (messages, polls, images)
+    chatRepository?.deleteConversation(conversationId = serieId)
   }
 
   /**

--- a/app/src/main/java/com/android/joinme/model/serie/SeriesRepositoryProvider.kt
+++ b/app/src/main/java/com/android/joinme/model/serie/SeriesRepositoryProvider.kt
@@ -1,6 +1,7 @@
 package com.android.joinme.model.serie
 
 import android.content.Context
+import com.android.joinme.model.chat.ChatRepositoryProvider
 import com.android.joinme.network.NetworkMonitor
 import com.google.firebase.Firebase
 import com.google.firebase.FirebaseApp
@@ -61,7 +62,9 @@ object SeriesRepositoryProvider {
 
   private fun getFirestoreRepo(): SeriesRepository {
     if (_firestoreRepository == null) {
-      _firestoreRepository = SeriesRepositoryFirestore(Firebase.firestore)
+      val chatRepository = ChatRepositoryProvider.repository
+      _firestoreRepository =
+          SeriesRepositoryFirestore(db = Firebase.firestore, chatRepository = chatRepository)
     }
     return _firestoreRepository!!
   }

--- a/app/src/test/java/com/android/joinme/model/groups/GroupRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/joinme/model/groups/GroupRepositoryFirestoreTest.kt
@@ -961,7 +961,9 @@ class GroupRepositoryFirestoreTest {
 
     // Mock Image Processor
     every { mockImageProcessor.processImage(mockUri) } returns processedBytes
-    repository = GroupRepositoryFirestore(mockDb, mockStorage) { mockImageProcessor }
+    repository =
+        GroupRepositoryFirestore(
+            db = mockDb, storage = mockStorage, imageProcessorFactory = { mockImageProcessor })
 
     // Mock Storage (using the fix for ClassCastException)
     val photoRef = setupStorageMocksForPhoto()
@@ -1002,7 +1004,9 @@ class GroupRepositoryFirestoreTest {
     val mockDownloadUri = mockk<Uri>()
 
     every { mockImageProcessor.processImage(mockUri) } returns processedBytes
-    repository = GroupRepositoryFirestore(mockDb, mockStorage) { mockImageProcessor }
+    repository =
+        GroupRepositoryFirestore(
+            db = mockDb, storage = mockStorage, imageProcessorFactory = { mockImageProcessor })
 
     // Mock Storage Success
     val photoRef = setupStorageMocksForPhoto()
@@ -1055,7 +1059,9 @@ class GroupRepositoryFirestoreTest {
     every { mockImageProcessor.processImage(mockUri) } throws Exception("Corrupt image")
 
     // Re-initialize repository
-    repository = GroupRepositoryFirestore(mockDb, mockStorage) { mockImageProcessor }
+    repository =
+        GroupRepositoryFirestore(
+            db = mockDb, storage = mockStorage, imageProcessorFactory = { mockImageProcessor })
 
     // When/Then
     val exception =

--- a/app/src/test/java/com/android/joinme/ui/chat/ChatScreenTest.kt
+++ b/app/src/test/java/com/android/joinme/ui/chat/ChatScreenTest.kt
@@ -1060,5 +1060,16 @@ class ChatScreenTest {
     ): String {
       return "mock://chat-image/$conversationId/$messageId.jpg"
     }
+
+    override suspend fun deleteConversation(
+        conversationId: String,
+        pollRepository: com.android.joinme.model.chat.PollRepository?
+    ) {
+      // No-op for testing
+    }
+
+    override suspend fun deleteAllUserConversations(userId: String) {
+      // No-op for testing
+    }
   }
 }

--- a/app/src/test/java/com/android/joinme/ui/chat/ChatViewModelTest.kt
+++ b/app/src/test/java/com/android/joinme/ui/chat/ChatViewModelTest.kt
@@ -184,6 +184,17 @@ class ChatViewModelTest {
       }
       return "https://storage.example.com/$conversationId/$messageId.jpg"
     }
+
+    override suspend fun deleteConversation(
+        conversationId: String,
+        pollRepository: com.android.joinme.model.chat.PollRepository?
+    ) {
+      // No-op for testing
+    }
+
+    override suspend fun deleteAllUserConversations(userId: String) {
+      // No-op for testing
+    }
   }
 
   private lateinit var fakeRepo: FakeChatRepository

--- a/app/src/test/java/com/android/joinme/ui/chat/PollUITest.kt
+++ b/app/src/test/java/com/android/joinme/ui/chat/PollUITest.kt
@@ -643,6 +643,17 @@ class PollUITest {
         messageId: String,
         imageUri: android.net.Uri
     ): String = ""
+
+    override suspend fun deleteConversation(
+        conversationId: String,
+        pollRepository: com.android.joinme.model.chat.PollRepository?
+    ) {
+      // No-op for testing
+    }
+
+    override suspend fun deleteAllUserConversations(userId: String) {
+      // No-op for testing
+    }
   }
 
   private class FakeProfileRepository : ProfileRepository {

--- a/app/src/test/java/com/android/joinme/ui/chat/PollViewModelTest.kt
+++ b/app/src/test/java/com/android/joinme/ui/chat/PollViewModelTest.kt
@@ -254,6 +254,17 @@ class PollViewModelTest {
         messageId: String,
         imageUri: android.net.Uri
     ): String = ""
+
+    override suspend fun deleteConversation(
+        conversationId: String,
+        pollRepository: com.android.joinme.model.chat.PollRepository?
+    ) {
+      // No-op for testing
+    }
+
+    override suspend fun deleteAllUserConversations(userId: String) {
+      // No-op for testing
+    }
   }
 
   private val testDispatcher = StandardTestDispatcher()


### PR DESCRIPTION
 ## Summary

  This PR implements proper conversation cleanup when events, series, groups, or profiles are deleted. Previously, conversations and their associated data (messages, photos, locations, polls) remained in the database even after the parent entity was deleted.

  ## Changes Made

  ### Core Implementation
  - **Added `deleteConversation(conversationId, pollRepository?)`** to `ChatRepository`
    - Deletes all messages in the conversation
    - Deletes all polls in the conversation
    - Deletes all images from Firebase Storage
    - Deletes the conversation node itself

  - **Added `deleteAllUserConversations(userId)`** to `ChatRepository`
    - Finds and deletes all DM conversations matching pattern `dm_{userId1}_{userId2}`
    - Used when profiles are deleted to clean up private conversations

  ### Integration Points
  - **EventsRepositoryFirestore**: Calls `deleteConversation()` when events are deleted
  - **SeriesRepositoryFirestore**: Calls `deleteConversation()` when series are deleted
  - **GroupRepositoryFirestore**: Calls `deleteConversation()` when groups are deleted
  - **ProfileRepositoryFirestore**: Calls `deleteAllUserConversations()` when profiles are deleted

  ### Repository Providers
  - Updated `EventsRepositoryProvider` to inject `ChatRepository`
  - Updated `SeriesRepositoryProvider` to inject `ChatRepository`
  - Updated `GroupRepositoryProvider` to inject `ChatRepository`
  - Updated `ProfileRepositoryProvider` to inject `ChatRepository`

  ### Testing
  Added comprehensive test coverage:
  - **ChatRepositoryLocalTest**: new tests for both methods
  - **ChatRepositoryRealtimeDatabaseTest**: new tests for Firebase implementation
  - Fixed all `FakeChatRepository` classes in UI tests
  - Test were made with help of ChatGPT AI

  ## What Gets Cleaned Up

  When an entity is deleted:
  - All messages in `conversations/{entityId}/messages/*`
  - All polls in `conversations/{entityId}/polls/*`
  - All images in Firebase Storage `conversations/{entityId}/images/*.jpg`
  - All locations embedded in messages
  - The conversation node itself

  When a profile is deleted:
  - All DM conversations where the user is a participant
  - All messages, images, and polls in those conversations