### PR TITLE
fix(group): delete events and series of groups on group deletion

### DIFF
--- a/app/src/main/java/com/android/joinme/model/groups/GroupRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/joinme/model/groups/GroupRepositoryFirestore.kt
@@ -5,6 +5,10 @@ import android.content.Context
 import android.net.Uri
 import android.util.Log
 import com.android.joinme.model.event.EventType
+import com.android.joinme.model.event.EventsRepository
+import com.android.joinme.model.event.EventsRepositoryProvider
+import com.android.joinme.model.serie.SeriesRepository
+import com.android.joinme.model.serie.SeriesRepositoryProvider
 import com.android.joinme.model.utils.ImageProcessor
 import com.android.joinme.util.TestEnvironmentDetector
 import com.google.firebase.Firebase
@@ -25,7 +29,9 @@ private const val F_PHOTO_URL = "photoUrl"
 class GroupRepositoryFirestore(
     private val db: FirebaseFirestore,
     private val storage: FirebaseStorage = FirebaseStorage.getInstance(),
-    private val imageProcessorFactory: (Context) -> ImageProcessor = { ImageProcessor(it) }
+    private val imageProcessorFactory: (Context) -> ImageProcessor = { ImageProcessor(it) },
+    private val eventsRepository: EventsRepository = EventsRepositoryProvider.getRepository(),
+    private val seriesRepository: SeriesRepository = SeriesRepositoryProvider.repository
 ) : GroupRepository {
 
   companion object {
@@ -78,6 +84,25 @@ class GroupRepositoryFirestore(
       throw Exception("GroupRepositoryFirestore: Only the group owner can delete this group")
     }
 
+    // Delete all events associated with this group
+    group.eventIds.forEach { eventId ->
+      try {
+        eventsRepository.deleteEvent(eventId)
+      } catch (e: Exception) {
+        Log.w(TAG, "Failed to delete event $eventId for group $groupId", e)
+      }
+    }
+
+    // Delete all series associated with this group (which will also delete their events)
+    group.serieIds.forEach { serieId ->
+      try {
+        seriesRepository.deleteSerie(serieId)
+      } catch (e: Exception) {
+        Log.w(TAG, "Failed to delete serie $serieId for group $groupId", e)
+      }
+    }
+
+    // Finally, delete the group itself
     db.collection(GROUPS_COLLECTION_PATH).document(groupId).delete().await()
   }
 

--- a/app/src/test/java/com/android/joinme/model/groups/GroupRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/android/joinme/model/groups/GroupRepositoryFirestoreTest.kt
@@ -18,6 +18,8 @@ import com.google.firebase.firestore.QuerySnapshot
 import com.google.firebase.storage.FirebaseStorage
 import com.google.firebase.storage.StorageReference
 import com.google.firebase.storage.UploadTask
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -42,6 +44,8 @@ class GroupRepositoryFirestoreTest {
   private lateinit var mockUser: FirebaseUser
   private lateinit var mockStorage: FirebaseStorage
   private lateinit var mockStorageRef: StorageReference
+  private lateinit var mockEventsRepository: com.android.joinme.model.event.EventsRepository
+  private lateinit var mockSeriesRepository: com.android.joinme.model.serie.SeriesRepository
   private lateinit var repository: GroupRepositoryFirestore
 
   private val testGroupId = "testGroup123"
@@ -75,12 +79,21 @@ class GroupRepositoryFirestoreTest {
     mockStorage = mockk(relaxed = true)
     mockStorageRef = mockk(relaxed = true)
 
+    // Mock Repositories
+    mockEventsRepository = mockk(relaxed = true)
+    mockSeriesRepository = mockk(relaxed = true)
+
     every { mockDb.collection(GROUPS_COLLECTION_PATH) } returns mockCollection
     every { mockCollection.document(any()) } returns mockDocument
     every { mockCollection.document() } returns mockDocument
     every { mockDocument.id } returns testGroupId
 
-    repository = GroupRepositoryFirestore(mockDb, mockStorage)
+    repository =
+        GroupRepositoryFirestore(
+            mockDb,
+            mockStorage,
+            eventsRepository = mockEventsRepository,
+            seriesRepository = mockSeriesRepository)
   }
 
   @Test
@@ -175,7 +188,11 @@ class GroupRepositoryFirestoreTest {
     every { mockSnapshot.getString("ownerId") } returns testUserId // User is owner
     every { mockSnapshot.get("memberIds") } returns testGroup.memberIds
     every { mockSnapshot.get("eventIds") } returns testGroup.eventIds
+    every { mockSnapshot.get("serieIds") } returns emptyList<String>()
     every { mockSnapshot.get("category") } returns null
+
+    // Mock repository deletions
+    coEvery { mockEventsRepository.deleteEvent(any()) } returns Unit
 
     // Mock delete operation
     every { mockDocument.delete() } returns Tasks.forResult(null)
@@ -310,7 +327,12 @@ class GroupRepositoryFirestoreTest {
     every { mockSnapshot.getString("ownerId") } returns testUserId
     every { mockSnapshot.get("memberIds") } returns group.memberIds
     every { mockSnapshot.get("eventIds") } returns group.eventIds
+    every { mockSnapshot.get("serieIds") } returns emptyList<String>()
     every { mockSnapshot.getString("photoUrl") } returns null
+
+    // Mock repository deletions
+    coEvery { mockEventsRepository.deleteEvent(any()) } returns Unit
+
     every { mockDocument.delete() } returns Tasks.forResult(null)
 
     // When
@@ -961,7 +983,13 @@ class GroupRepositoryFirestoreTest {
 
     // Mock Image Processor
     every { mockImageProcessor.processImage(mockUri) } returns processedBytes
-    repository = GroupRepositoryFirestore(mockDb, mockStorage) { mockImageProcessor }
+    repository =
+        GroupRepositoryFirestore(
+            mockDb,
+            mockStorage,
+            imageProcessorFactory = { mockImageProcessor },
+            eventsRepository = mockEventsRepository,
+            seriesRepository = mockSeriesRepository)
 
     // Mock Storage (using the fix for ClassCastException)
     val photoRef = setupStorageMocksForPhoto()
@@ -1002,7 +1030,13 @@ class GroupRepositoryFirestoreTest {
     val mockDownloadUri = mockk<Uri>()
 
     every { mockImageProcessor.processImage(mockUri) } returns processedBytes
-    repository = GroupRepositoryFirestore(mockDb, mockStorage) { mockImageProcessor }
+    repository =
+        GroupRepositoryFirestore(
+            mockDb,
+            mockStorage,
+            imageProcessorFactory = { mockImageProcessor },
+            eventsRepository = mockEventsRepository,
+            seriesRepository = mockSeriesRepository)
 
     // Mock Storage Success
     val photoRef = setupStorageMocksForPhoto()
@@ -1055,7 +1089,13 @@ class GroupRepositoryFirestoreTest {
     every { mockImageProcessor.processImage(mockUri) } throws Exception("Corrupt image")
 
     // Re-initialize repository
-    repository = GroupRepositoryFirestore(mockDb, mockStorage) { mockImageProcessor }
+    repository =
+        GroupRepositoryFirestore(
+            mockDb,
+            mockStorage,
+            imageProcessorFactory = { mockImageProcessor },
+            eventsRepository = mockEventsRepository,
+            seriesRepository = mockSeriesRepository)
 
     // When/Then
     val exception =
@@ -1110,5 +1150,64 @@ class GroupRepositoryFirestoreTest {
 
     // Then
     verify { mockDocument.update("photoUrl", null) }
+  }
+
+  // =======================================
+  // Cascade Deletion Tests
+  // =======================================
+
+  /** Helper to setup group with events and series for cascade deletion tests. */
+  private fun setupGroupDeletionMocks(
+      eventIds: List<String> = listOf("event1", "event2"),
+      serieIds: List<String> = listOf("serie1")
+  ) {
+    val group = createTestGroup().copy(eventIds = eventIds, serieIds = serieIds)
+
+    // Mock getGroup
+    every { mockSnapshot.id } returns testGroupId
+    every { mockSnapshot.getString("name") } returns group.name
+    every { mockSnapshot.getString("category") } returns "SPORTS"
+    every { mockSnapshot.getString("description") } returns group.description
+    every { mockSnapshot.getString("ownerId") } returns testUserId
+    every { mockSnapshot.get("memberIds") } returns group.memberIds
+    every { mockSnapshot.get("eventIds") } returns eventIds
+    every { mockSnapshot.get("serieIds") } returns serieIds
+    every { mockSnapshot.getString("photoUrl") } returns null
+    every { mockDocument.get() } returns Tasks.forResult(mockSnapshot)
+
+    // Mock repository deletions
+    coEvery { mockEventsRepository.deleteEvent(any()) } returns Unit
+    coEvery { mockSeriesRepository.deleteSerie(any()) } returns Unit
+
+    every { mockDocument.delete() } returns Tasks.forResult(null)
+  }
+
+  @Test
+  fun deleteGroup_cascadesEventsAndSeriesDeletion() = runTest {
+    // Given
+    setupGroupDeletionMocks()
+
+    // When
+    repository.deleteGroup(testGroupId, testUserId)
+
+    // Then
+    coVerify { mockEventsRepository.deleteEvent("event1") }
+    coVerify { mockEventsRepository.deleteEvent("event2") }
+    coVerify { mockSeriesRepository.deleteSerie("serie1") }
+    verify { mockDocument.delete() }
+  }
+
+  @Test
+  fun deleteGroup_withNoEventsOrSeries_deletesGroupOnly() = runTest {
+    // Given
+    setupGroupDeletionMocks(eventIds = emptyList(), serieIds = emptyList())
+
+    // When
+    repository.deleteGroup(testGroupId, testUserId)
+
+    // Then
+    verify { mockDocument.delete() }
+    coVerify(exactly = 0) { mockEventsRepository.deleteEvent(any()) }
+    coVerify(exactly = 0) { mockSeriesRepository.deleteSerie(any()) }
   }
 }


### PR DESCRIPTION
## Description
  Implement cascade deletion of events and series when a group is deleted.

## Changes
  - Modified `GroupRepositoryFirestore.deleteGroup()` to delete all associated events and series before deleting the group
  - Injected `EventsRepository` and `SeriesRepository` dependencies to reuse existing deletion logic

## Issue
Closes #504 

Note: This description was co-written with AI (Claude).