### PR TITLE
feat(event): add clickable location

### DIFF
--- a/app/src/main/java/com/android/joinme/MainActivity.kt
+++ b/app/src/main/java/com/android/joinme/MainActivity.kt
@@ -534,6 +534,9 @@ fun JoinMe(
               },
               onNavigateToChat = { chatId, chatTitle, totalParticipants ->
                 navigationActions.navigateTo(Screen.Chat(chatId, chatTitle, totalParticipants))
+              },
+              onNavigateToMap = { location ->
+                navigationActions.navigateTo(Screen.Map(location.latitude, location.longitude))
               })
         } ?: run { Toast.makeText(context, "Event UID is null", Toast.LENGTH_SHORT).show() }
       }

--- a/app/src/main/java/com/android/joinme/ui/overview/ShowEventScreen.kt
+++ b/app/src/main/java/com/android/joinme/ui/overview/ShowEventScreen.kt
@@ -1,6 +1,7 @@
 package com.android.joinme.ui.overview
 
 import android.widget.Toast
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -9,6 +10,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Message
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material3.*
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.*
@@ -242,7 +244,8 @@ fun ShowEventScreen(
     onGoBack: () -> Unit = {},
     onEditEvent: (String) -> Unit = {},
     onEditEventForSerie: (String, String) -> Unit = { _, _ -> },
-    onNavigateToChat: (String, String, Int) -> Unit = { _, _, _ -> }
+    onNavigateToChat: (String, String, Int) -> Unit = { _, _, _ -> },
+    onNavigateToMap: (com.android.joinme.model.map.Location) -> Unit = {}
 ) {
   LaunchedEffect(eventId, serieId) { showEventViewModel.loadEvent(eventId, serieId) }
 
@@ -383,12 +386,26 @@ fun ShowEventScreen(
                   thickness = Dimens.BorderWidth.thin, color = MaterialTheme.colorScheme.primary)
 
               // Location
-              Text(
-                  text = eventUIState.location,
-                  style = MaterialTheme.typography.bodyMedium,
-                  color = MaterialTheme.colorScheme.onSurfaceVariant,
+              Row(
                   modifier =
-                      Modifier.fillMaxWidth().testTag(ShowEventScreenTestTags.EVENT_LOCATION))
+                      Modifier.fillMaxWidth()
+                          .clickable {
+                            eventUIState.locationObject?.let { location ->
+                              onNavigateToMap(location)
+                            }
+                          }
+                          .testTag(ShowEventScreenTestTags.EVENT_LOCATION),
+                  horizontalArrangement = Arrangement.spacedBy(Dimens.Spacing.small),
+                  verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.LocationOn,
+                        contentDescription = stringResource(R.string.view_on_map),
+                        tint = MaterialTheme.colorScheme.primary)
+                    Text(
+                        text = eventUIState.location,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.primary)
+                  }
 
               HorizontalDivider(
                   thickness = Dimens.BorderWidth.thin, color = MaterialTheme.colorScheme.primary)

--- a/app/src/main/java/com/android/joinme/ui/overview/ShowEventViewModel.kt
+++ b/app/src/main/java/com/android/joinme/ui/overview/ShowEventViewModel.kt
@@ -12,6 +12,7 @@ import com.android.joinme.model.event.isUpcoming
 import com.android.joinme.model.groups.GroupRepository
 import com.android.joinme.model.groups.GroupRepositoryProvider
 import com.android.joinme.model.groups.streaks.StreakService
+import com.android.joinme.model.map.Location
 import com.android.joinme.model.profile.Profile
 import com.android.joinme.model.profile.ProfileRepository
 import com.android.joinme.model.profile.ProfileRepositoryProvider
@@ -29,6 +30,7 @@ data class ShowEventUIState(
     val title: String = "",
     val description: String = "",
     val location: String = "",
+    val locationObject: Location? = null,
     val maxParticipants: String = "",
     val participantsCount: String = "",
     val duration: String = "",
@@ -114,6 +116,7 @@ class ShowEventViewModel(
                 title = event.title,
                 description = event.description,
                 location = event.location?.name ?: "",
+                locationObject = event.location,
                 maxParticipants = event.maxParticipants.toString(),
                 participantsCount = event.participants.size.toString(),
                 duration = event.duration.toString(),

--- a/app/src/test/java/com/android/joinme/ui/overview/ShowEventViewModelTest.kt
+++ b/app/src/test/java/com/android/joinme/ui/overview/ShowEventViewModelTest.kt
@@ -138,6 +138,10 @@ class ShowEventViewModelTest {
     assertEquals("Basketball Game", state.title)
     assertEquals("Friendly 3v3 basketball match", state.description)
     assertEquals("EPFL", state.location)
+    assertNotNull(state.locationObject)
+    assertEquals(46.5197, state.locationObject?.latitude ?: 0.0, 0.001)
+    assertEquals(6.6323, state.locationObject?.longitude ?: 0.0, 0.001)
+    assertEquals("EPFL", state.locationObject?.name)
     assertEquals("10", state.maxParticipants)
     assertEquals("3", state.participantsCount)
     assertEquals("90", state.duration)
@@ -800,6 +804,7 @@ class ShowEventViewModelTest {
     assertEquals("", state.title)
     assertEquals("", state.description)
     assertEquals("", state.location)
+    assertNull(state.locationObject)
     assertEquals("", state.maxParticipants)
     assertEquals("", state.participantsCount)
     assertEquals("", state.duration)
@@ -894,6 +899,7 @@ class ShowEventViewModelTest {
 
     val state = viewModel.uiState.first()
     assertEquals("", state.location)
+    assertNull(state.locationObject)
   }
 
   @Test
@@ -909,6 +915,8 @@ class ShowEventViewModelTest {
 
     val state = viewModel.uiState.first()
     assertEquals("EPFL", state.location)
+    assertNotNull(state.locationObject)
+    assertEquals("EPFL", state.locationObject?.name)
   }
 
   /** --- EVENT TYPE TESTS --- */


### PR DESCRIPTION
## Description

This PR adds location navigation from ShowEventScreen to MapScreen.When users click on an event's location in ShowEventScreen, they are now navigated to MapScreen centered on that location's coordinates.

## Changes

  - ShowEventScreen: Made event location clickable with a location icon and
  primary color styling to indicate interactivity
  - ShowEventViewModel: Added locationObject field to UI state to store the
  full Location object
  - MainActivity: Wired up onNavigateToMap callback to navigate to MapScreen
   with location coordinates

## Screenshots

<img width="200" height="500" alt="Capture d’écran 2025-12-13 à 20 59 54" src="https://github.com/user-attachments/assets/9bf66b9a-932d-45d4-9705-8eb04a4086fc" />

<img width="200" height="500" alt="Capture d’écran 2025-12-13 à 21 00 11" src="https://github.com/user-attachments/assets/d2b2e5b9-07ca-4eec-bd51-a22d9ecbaee9" />

## Issue

Closes #408 