### PR TITLE
feat(navigation): added navigation to followers from private profile

### DIFF
--- a/app/src/main/java/com/android/joinme/MainActivity.kt
+++ b/app/src/main/java/com/android/joinme/MainActivity.kt
@@ -757,6 +757,16 @@ private fun NavGraphBuilder.profileScreens(
         onSignOutComplete = {
           FCMTokenManager.clearFCMToken()
           navigationActions.navigateTo(Screen.Auth)
+        },
+        onFollowersClick = { profileUserId ->
+          navigationActions.navigateTo(
+              Screen.FollowList(
+                  profileUserId, com.android.joinme.ui.profile.FollowTab.FOLLOWERS.name))
+        },
+        onFollowingClick = { profileUserId ->
+          navigationActions.navigateTo(
+              Screen.FollowList(
+                  profileUserId, com.android.joinme.ui.profile.FollowTab.FOLLOWING.name))
         })
   }
   composable(Screen.PublicProfile.route) { navBackStackEntry ->

--- a/app/src/main/java/com/android/joinme/ui/profile/ViewProfile.kt
+++ b/app/src/main/java/com/android/joinme/ui/profile/ViewProfile.kt
@@ -63,6 +63,8 @@ fun ViewProfileScreen(
     onGroupClick: () -> Unit = {},
     onEditClick: () -> Unit = {},
     onSignOutComplete: () -> Unit = {},
+    onFollowersClick: (String) -> Unit = {},
+    onFollowingClick: (String) -> Unit = {},
 ) {
   val profile by profileViewModel.profile.collectAsState()
   val isLoading by profileViewModel.isLoading.collectAsState()
@@ -125,7 +127,9 @@ fun ViewProfileScreen(
                     profileViewModel.signOut(
                         onSignOutComplete,
                         onError = { profileViewModel.setError("Error while logging out") })
-                  })
+                  },
+                  onFollowersClick = { onFollowersClick(uid) },
+                  onFollowingClick = { onFollowingClick(uid) })
             }
             else -> {
               Text(text = "No profile data available", modifier = Modifier.align(Alignment.Center))
@@ -137,7 +141,12 @@ fun ViewProfileScreen(
 
 /** The main content of the profile screen, displaying profile details in read-only mode. */
 @Composable
-private fun ProfileContent(profile: Profile, onLogoutClick: () -> Unit) {
+private fun ProfileContent(
+    profile: Profile,
+    onLogoutClick: () -> Unit,
+    onFollowersClick: () -> Unit,
+    onFollowingClick: () -> Unit
+) {
   var showLogoutDialog by remember { mutableStateOf(false) }
 
   Column(
@@ -184,7 +193,9 @@ private fun ProfileContent(profile: Profile, onLogoutClick: () -> Unit) {
             eventsJoinedTestTag = ViewProfileTestTags.EVENTS_JOINED_STAT,
             followersTestTag = ViewProfileTestTags.FOLLOWERS_STAT,
             followingTestTag = ViewProfileTestTags.FOLLOWING_STAT,
-            profilePhotoTestTag = ViewProfileTestTags.PROFILE_PICTURE)
+            profilePhotoTestTag = ViewProfileTestTags.PROFILE_PICTURE,
+            onFollowersClick = onFollowersClick,
+            onFollowingClick = onFollowingClick)
 
         // Event Streaks
         Box(

--- a/app/src/test/java/com/android/joinme/ui/profile/ViewProfileTest.kt
+++ b/app/src/test/java/com/android/joinme/ui/profile/ViewProfileTest.kt
@@ -570,6 +570,85 @@ class ViewProfileScreenTest {
     composeTestRule.onNodeWithText("28.8m").assertIsDisplayed()
   }
 
+  @Test
+  fun viewProfileScreen_followersStat_isClickable() = runTest {
+    val repo = FakeProfileRepository(createTestProfile())
+    val viewModel = ProfileViewModel(repo)
+
+    composeTestRule.setContent { ViewProfileScreen(uid = testUid, profileViewModel = viewModel) }
+
+    composeTestRule.onNodeWithTag(ViewProfileTestTags.FOLLOWERS_STAT).assertHasClickAction()
+  }
+
+  @Test
+  fun viewProfileScreen_followingStat_isClickable() = runTest {
+    val repo = FakeProfileRepository(createTestProfile())
+    val viewModel = ProfileViewModel(repo)
+
+    composeTestRule.setContent { ViewProfileScreen(uid = testUid, profileViewModel = viewModel) }
+
+    composeTestRule.onNodeWithTag(ViewProfileTestTags.FOLLOWING_STAT).assertHasClickAction()
+  }
+
+  @Test
+  fun viewProfileScreen_followersStat_click_triggersCallback() = runTest {
+    val repo = FakeProfileRepository(createTestProfile())
+    val viewModel = ProfileViewModel(repo)
+    var clickedUserId: String? = null
+
+    composeTestRule.setContent {
+      ViewProfileScreen(
+          uid = testUid,
+          profileViewModel = viewModel,
+          onFollowersClick = { userId -> clickedUserId = userId })
+    }
+
+    composeTestRule.onNodeWithTag(ViewProfileTestTags.FOLLOWERS_STAT).performClick()
+    assert(clickedUserId == testUid) { "Expected uid $testUid but got $clickedUserId" }
+  }
+
+  @Test
+  fun viewProfileScreen_followingStat_click_triggersCallback() = runTest {
+    val repo = FakeProfileRepository(createTestProfile())
+    val viewModel = ProfileViewModel(repo)
+    var clickedUserId: String? = null
+
+    composeTestRule.setContent {
+      ViewProfileScreen(
+          uid = testUid,
+          profileViewModel = viewModel,
+          onFollowingClick = { userId -> clickedUserId = userId })
+    }
+
+    composeTestRule.onNodeWithTag(ViewProfileTestTags.FOLLOWING_STAT).performClick()
+    assert(clickedUserId == testUid) { "Expected uid $testUid but got $clickedUserId" }
+  }
+
+  @Test
+  fun viewProfileScreen_followerAndFollowingStats_independentCallbacks() = runTest {
+    val repo = FakeProfileRepository(createTestProfile())
+    val viewModel = ProfileViewModel(repo)
+    var followersClickedUserId: String? = null
+    var followingClickedUserId: String? = null
+
+    composeTestRule.setContent {
+      ViewProfileScreen(
+          uid = testUid,
+          profileViewModel = viewModel,
+          onFollowersClick = { userId -> followersClickedUserId = userId },
+          onFollowingClick = { userId -> followingClickedUserId = userId })
+    }
+
+    // Click followers stat
+    composeTestRule.onNodeWithTag(ViewProfileTestTags.FOLLOWERS_STAT).performClick()
+    assert(followersClickedUserId == testUid) { "Followers callback not triggered" }
+    assert(followingClickedUserId == null) { "Following callback should not be triggered" }
+
+    // Click following stat
+    composeTestRule.onNodeWithTag(ViewProfileTestTags.FOLLOWING_STAT).performClick()
+    assert(followingClickedUserId == testUid) { "Following callback not triggered" }
+  }
+
   // ==================== LAUNCHED EFFECT OPTIMIZATION TESTS ====================
 
   @Test


### PR DESCRIPTION
Added navigation to the Follow list screen from the private profile. It now behaves as in the public profile.

### Note on coverage
The MainActivity is hard to test for the same reason as in the public profile.

### Issue: 
Closes issue #548 